### PR TITLE
Fix issue #52: macOS File Menu

### DIFF
--- a/src/app_menu.rs
+++ b/src/app_menu.rs
@@ -692,8 +692,40 @@ fn build_menus(
             .collect()
     };
 
-    vec![
-        Menu {
+    #[cfg(target_os = "macos")]
+    let initial_menus = {
+        // On macOS, the first menu is the app menu (macOS overrides its title
+        // with the app name). File operations go in a separate "File" menu to
+        // match standard macOS conventions.
+        vec![
+            Menu {
+                name: "Velotype".into(),
+                items: vec![
+                    MenuItem::action(strings.menu_new_window.clone(), NewWindow),
+                    MenuItem::action(strings.menu_preferences.clone(), OpenPreferences),
+                    MenuItem::separator(),
+                    MenuItem::action(strings.menu_quit.clone(), QuitApplication),
+                ],
+            },
+            Menu {
+                name: strings.menu_file.into(),
+                items: vec![
+                    MenuItem::action(strings.menu_open_file.clone(), OpenFile),
+                    MenuItem::submenu(Menu {
+                        name: strings.menu_open_recent_file.clone().into(),
+                        items: recent_items,
+                    }),
+                    MenuItem::separator(),
+                    MenuItem::action(strings.menu_save.clone(), SaveDocument),
+                    MenuItem::action(strings.menu_save_as.clone(), SaveDocumentAs),
+                ],
+            },
+        ]
+    };
+
+    #[cfg(not(target_os = "macos"))]
+    let initial_menus = {
+        vec![Menu {
             name: strings.menu_file.into(),
             items: vec![
                 MenuItem::action(strings.menu_new_window.clone(), NewWindow),
@@ -709,7 +741,44 @@ fn build_menus(
                 MenuItem::separator(),
                 MenuItem::action(strings.menu_quit.clone(), QuitApplication),
             ],
-        },
+        }]
+    };
+
+    #[cfg(target_os = "macos")]
+    let help_items = {
+        // Show different menu item depending on whether CLI is already
+        // installed pointing to the current app.  Only portable
+        // installations (drag-installed .app bundles) need this —
+        // pkg-installed apps manage the symlink via postinstall.
+        let cli_installed = is_cli_symlink_current_app();
+        let mut items = vec![
+            MenuItem::action(strings.menu_check_updates.clone(), CheckForUpdates),
+            MenuItem::separator(),
+        ];
+        if cli_installed {
+            items.push(MenuItem::action(
+                SharedString::new(strings.menu_uninstall_cli_tool.as_str()),
+                UninstallCliTool,
+            ));
+        } else {
+            items.push(MenuItem::action(
+                SharedString::new(strings.menu_install_cli_tool.as_str()),
+                InstallCliTool,
+            ));
+        }
+        items.push(MenuItem::separator());
+        items.push(MenuItem::action(strings.menu_about.clone(), ShowAbout));
+        items
+    };
+    #[cfg(not(target_os = "macos"))]
+    let help_items = vec![
+        MenuItem::action(strings.menu_check_updates.clone(), CheckForUpdates),
+        MenuItem::separator(),
+        MenuItem::action(strings.menu_about.clone(), ShowAbout),
+    ];
+
+    let mut menus = initial_menus;
+    menus.extend([
         Menu {
             name: strings.menu_export.into(),
             items: vec![
@@ -732,46 +801,12 @@ fn build_menus(
                 ToggleWorkspace,
             )],
         },
-        {
-            #[cfg(target_os = "macos")]
-            let help_items = {
-                // Show different menu item depending on whether CLI is already
-                // installed pointing to the current app.  Only portable
-                // installations (drag-installed .app bundles) need this —
-                // pkg-installed apps manage the symlink via postinstall.
-                let cli_installed = is_cli_symlink_current_app();
-                let mut items = vec![
-                    MenuItem::action(strings.menu_check_updates.clone(), CheckForUpdates),
-                    MenuItem::separator(),
-                ];
-                if cli_installed {
-                    items.push(MenuItem::action(
-                        SharedString::new(strings.menu_uninstall_cli_tool.as_str()),
-                        UninstallCliTool,
-                    ));
-                } else {
-                    items.push(MenuItem::action(
-                        SharedString::new(strings.menu_install_cli_tool.as_str()),
-                        InstallCliTool,
-                    ));
-                }
-                items.push(MenuItem::separator());
-                items.push(MenuItem::action(strings.menu_about.clone(), ShowAbout));
-                items
-            };
-            #[cfg(not(target_os = "macos"))]
-            let help_items = vec![
-                MenuItem::action(strings.menu_check_updates.clone(), CheckForUpdates),
-                MenuItem::separator(),
-                MenuItem::action(strings.menu_about.clone(), ShowAbout),
-            ];
-
-            Menu {
-                name: strings.menu_help.into(),
-                items: help_items,
-            }
+        Menu {
+            name: strings.menu_help.into(),
+            items: help_items,
         },
-    ]
+    ]);
+    menus
 }
 
 pub(crate) fn install_menus(cx: &mut App) {
@@ -1062,6 +1097,33 @@ mod tests {
         );
     }
 
+    // On macOS the menu bar is: [Velotype app menu, File, Export, Language, Theme, Workspace, Help]
+    // On other platforms:       [File, Export, Language, Theme, Workspace, Help]
+    #[cfg(target_os = "macos")]
+    const EXPORT_IDX: usize = 2;
+    #[cfg(not(target_os = "macos"))]
+    const EXPORT_IDX: usize = 1;
+
+    #[cfg(target_os = "macos")]
+    const LANGUAGE_IDX: usize = 3;
+    #[cfg(not(target_os = "macos"))]
+    const LANGUAGE_IDX: usize = 2;
+
+    #[cfg(target_os = "macos")]
+    const THEME_IDX: usize = 4;
+    #[cfg(not(target_os = "macos"))]
+    const THEME_IDX: usize = 3;
+
+    #[cfg(target_os = "macos")]
+    const WORKSPACE_IDX: usize = 5;
+    #[cfg(not(target_os = "macos"))]
+    const WORKSPACE_IDX: usize = 4;
+
+    #[cfg(target_os = "macos")]
+    const HELP_IDX: usize = 6;
+    #[cfg(not(target_os = "macos"))]
+    const HELP_IDX: usize = 5;
+
     #[test]
     fn build_menus_uses_english_fallback_by_default() {
         let theme_manager = ThemeManager::default();
@@ -1072,21 +1134,44 @@ mod tests {
             .iter()
             .map(|menu| menu.name.to_string())
             .collect::<Vec<_>>();
+
+        #[cfg(target_os = "macos")]
+        assert_eq!(
+            menu_names,
+            vec!["Velotype", "File", "Export", "Language", "Theme", "Workspace", "Help"]
+        );
+        #[cfg(not(target_os = "macos"))]
         assert_eq!(
             menu_names,
             vec!["File", "Export", "Language", "Theme", "Workspace", "Help"]
         );
+
+        // App menu (index 0): New Window is always first regardless of platform.
         assert_eq!(action_name(&menus[0].items[0]), "New Window");
+
+        // Open Recent File submenu location differs by platform.
+        #[cfg(target_os = "macos")]
+        assert_eq!(
+            submenu(&menus[1].items[1]).name.to_string(),
+            "Open Recent File"
+        );
+        #[cfg(not(target_os = "macos"))]
         assert_eq!(
             submenu(&menus[0].items[2]).name.to_string(),
             "Open Recent File"
         );
+
+        // Preferences location differs by platform.
+        #[cfg(target_os = "macos")]
+        assert_eq!(action_name(&menus[0].items[1]), "Preferences");
+        #[cfg(not(target_os = "macos"))]
         assert_eq!(action_name(&menus[0].items[3]), "Preferences");
-        assert_eq!(action_name(&menus[1].items[0]), "HTML");
-        assert_eq!(action_name(&menus[1].items[1]), "PDF");
-        assert_eq!(action_name(&menus[2].items[0]), "简体中文");
-        assert_eq!(action_name(&menus[2].items[1]), "\u{2713} English");
-        assert_eq!(action_name(&menus[4].items[0]), "Toggle Workspace");
+
+        assert_eq!(action_name(&menus[EXPORT_IDX].items[0]), "HTML");
+        assert_eq!(action_name(&menus[EXPORT_IDX].items[1]), "PDF");
+        assert_eq!(action_name(&menus[LANGUAGE_IDX].items[0]), "简体中文");
+        assert_eq!(action_name(&menus[LANGUAGE_IDX].items[1]), "\u{2713} English");
+        assert_eq!(action_name(&menus[WORKSPACE_IDX].items[0]), "Toggle Workspace");
     }
 
     #[test]
@@ -1095,6 +1180,12 @@ mod tests {
         let i18n_manager = I18nManager::new_with_language_id("zh-CN");
         let menus = build_menus(&theme_manager, &i18n_manager, &[]);
 
+        #[cfg(target_os = "macos")]
+        assert_eq!(
+            submenu(&menus[1].items[1]).name.to_string(),
+            i18n_manager.strings().menu_open_recent_file.as_str()
+        );
+        #[cfg(not(target_os = "macos"))]
         assert_eq!(
             submenu(&menus[0].items[2]).name.to_string(),
             i18n_manager.strings().menu_open_recent_file.as_str()
@@ -1104,16 +1195,24 @@ mod tests {
             .iter()
             .map(|menu| menu.name.to_string())
             .collect::<Vec<_>>();
+
+        #[cfg(target_os = "macos")]
+        assert_eq!(
+            menu_names,
+            vec!["Velotype", "文件", "导出", "语言", "主题", "工作区", "帮助"]
+        );
+        #[cfg(not(target_os = "macos"))]
         assert_eq!(
             menu_names,
             vec!["文件", "导出", "语言", "主题", "工作区", "帮助"]
         );
+
         assert_eq!(action_name(&menus[0].items[0]), "新建窗口");
-        assert_eq!(action_name(&menus[1].items[0]), "HTML");
-        assert_eq!(action_name(&menus[1].items[1]), "PDF");
-        assert_eq!(action_name(&menus[2].items[0]), "\u{2713} 简体中文");
-        assert_eq!(action_name(&menus[2].items[1]), "English");
-        assert_eq!(action_name(&menus[4].items[0]), "切换工作区");
+        assert_eq!(action_name(&menus[EXPORT_IDX].items[0]), "HTML");
+        assert_eq!(action_name(&menus[EXPORT_IDX].items[1]), "PDF");
+        assert_eq!(action_name(&menus[LANGUAGE_IDX].items[0]), "\u{2713} 简体中文");
+        assert_eq!(action_name(&menus[LANGUAGE_IDX].items[1]), "English");
+        assert_eq!(action_name(&menus[WORKSPACE_IDX].items[0]), "切换工作区");
     }
 
     #[test]
@@ -1122,14 +1221,14 @@ mod tests {
         let i18n_manager = I18nManager::default();
         let menus = build_menus(&theme_manager, &i18n_manager, &[]);
 
-        match &menus[1].items[0] {
+        match &menus[EXPORT_IDX].items[0] {
             MenuItem::Action { action, .. } => {
                 assert!(action.as_any().is::<ExportHtml>());
             }
             _ => panic!("expected export html action item"),
         }
 
-        match &menus[1].items[1] {
+        match &menus[EXPORT_IDX].items[1] {
             MenuItem::Action { action, .. } => {
                 assert!(action.as_any().is::<ExportPdf>());
             }
@@ -1143,7 +1242,7 @@ mod tests {
         let i18n_manager = I18nManager::default();
         let menus = build_menus(&theme_manager, &i18n_manager, &[]);
 
-        match &menus[2].items[0] {
+        match &menus[LANGUAGE_IDX].items[0] {
             MenuItem::Action { action, .. } => {
                 let action = action
                     .as_any()
@@ -1160,6 +1259,12 @@ mod tests {
         let theme_manager = ThemeManager::default();
         let i18n_manager = I18nManager::default();
         let menus = build_menus(&theme_manager, &i18n_manager, &[]);
+
+        // On macOS: File menu is index 1, Open Recent is item 1 within it.
+        // On other platforms: File menu is index 0, Open Recent is item 2.
+        #[cfg(target_os = "macos")]
+        let recent_menu = submenu(&menus[1].items[1]);
+        #[cfg(not(target_os = "macos"))]
         let recent_menu = submenu(&menus[0].items[2]);
 
         assert_eq!(recent_menu.name.to_string(), "Open Recent File");
@@ -1182,6 +1287,10 @@ mod tests {
             PathBuf::from(r"D:\notes\two.markdown"),
         ];
         let menus = build_menus(&theme_manager, &i18n_manager, &recent_files);
+
+        #[cfg(target_os = "macos")]
+        let recent_menu = submenu(&menus[1].items[1]);
+        #[cfg(not(target_os = "macos"))]
         let recent_menu = submenu(&menus[0].items[2]);
 
         assert_eq!(recent_menu.items.len(), 2);
@@ -1225,7 +1334,7 @@ mod tests {
         let i18n_manager = I18nManager::default();
         let menus = build_menus(&theme_manager, &i18n_manager, &[]);
 
-        let language_items = &menus[2].items;
+        let language_items = &menus[LANGUAGE_IDX].items;
         assert!(matches!(
             language_items[language_items.len() - 2],
             MenuItem::Separator
@@ -1241,7 +1350,7 @@ mod tests {
             _ => panic!("expected add language config action item"),
         }
 
-        let theme_items = &menus[3].items;
+        let theme_items = &menus[THEME_IDX].items;
         assert_eq!(action_name(&theme_items[0]), "\u{2713} Velotype");
         assert_eq!(action_name(&theme_items[1]), "Velotype Light");
         assert!(matches!(
@@ -1272,7 +1381,7 @@ mod tests {
         assert!(theme_manager.set_theme_by_id("velotype-light"));
         let i18n_manager = I18nManager::default();
         let menus = build_menus(&theme_manager, &i18n_manager, &[]);
-        let theme_items = &menus[3].items;
+        let theme_items = &menus[THEME_IDX].items;
 
         assert_eq!(action_name(&theme_items[0]), "Velotype");
         assert_eq!(action_name(&theme_items[1]), "\u{2713} Velotype Light");
@@ -1289,13 +1398,12 @@ mod tests {
     }
 
     #[test]
-    fn help_menu_contains_update_and_about_only() {
+    fn help_menu_first_item_is_check_for_updates() {
         let theme_manager = ThemeManager::default();
         let i18n_manager = I18nManager::default();
         let menus = build_menus(&theme_manager, &i18n_manager, &[]);
-        let help_items = &menus[5].items;
+        let help_items = &menus[HELP_IDX].items;
 
-        assert_eq!(help_items.len(), 3);
         match &help_items[0] {
             MenuItem::Action { action, .. } => {
                 assert!(action.as_any().is::<CheckForUpdates>());
@@ -1303,7 +1411,37 @@ mod tests {
             _ => panic!("expected check updates action item"),
         }
         assert!(matches!(help_items[1], MenuItem::Separator));
+    }
+
+    #[test]
+    #[cfg(not(target_os = "macos"))]
+    fn help_menu_contains_update_and_about_only() {
+        let theme_manager = ThemeManager::default();
+        let i18n_manager = I18nManager::default();
+        let menus = build_menus(&theme_manager, &i18n_manager, &[]);
+        let help_items = &menus[HELP_IDX].items;
+
+        assert_eq!(help_items.len(), 3);
         match &help_items[2] {
+            MenuItem::Action { action, .. } => {
+                assert!(action.as_any().is::<ShowAbout>());
+            }
+            _ => panic!("expected about action item"),
+        }
+    }
+
+    #[test]
+    #[cfg(target_os = "macos")]
+    fn help_menu_contains_cli_and_about_on_macos() {
+        let theme_manager = ThemeManager::default();
+        let i18n_manager = I18nManager::default();
+        let menus = build_menus(&theme_manager, &i18n_manager, &[]);
+        let help_items = &menus[HELP_IDX].items;
+
+        // CheckForUpdates, separator, Install/Uninstall CLI, separator, About
+        assert_eq!(help_items.len(), 5);
+        assert!(matches!(help_items[3], MenuItem::Separator));
+        match &help_items[4] {
             MenuItem::Action { action, .. } => {
                 assert!(action.as_any().is::<ShowAbout>());
             }

--- a/src/app_menu.rs
+++ b/src/app_menu.rs
@@ -701,7 +701,6 @@ fn build_menus(
             Menu {
                 name: "Velotype".into(),
                 items: vec![
-                    MenuItem::action(strings.menu_new_window.clone(), NewWindow),
                     MenuItem::action(strings.menu_preferences.clone(), OpenPreferences),
                     MenuItem::separator(),
                     MenuItem::action(strings.menu_quit.clone(), QuitApplication),
@@ -710,6 +709,7 @@ fn build_menus(
             Menu {
                 name: strings.menu_file.into(),
                 items: vec![
+                    MenuItem::action(strings.menu_new_window.clone(), NewWindow),
                     MenuItem::action(strings.menu_open_file.clone(), OpenFile),
                     MenuItem::submenu(Menu {
                         name: strings.menu_open_recent_file.clone().into(),
@@ -1138,7 +1138,15 @@ mod tests {
         #[cfg(target_os = "macos")]
         assert_eq!(
             menu_names,
-            vec!["Velotype", "File", "Export", "Language", "Theme", "Workspace", "Help"]
+            vec![
+                "Velotype",
+                "File",
+                "Export",
+                "Language",
+                "Theme",
+                "Workspace",
+                "Help"
+            ]
         );
         #[cfg(not(target_os = "macos"))]
         assert_eq!(
@@ -1146,13 +1154,17 @@ mod tests {
             vec!["File", "Export", "Language", "Theme", "Workspace", "Help"]
         );
 
-        // App menu (index 0): New Window is always first regardless of platform.
+        // New Window belongs with file operations on macOS and remains the
+        // first File menu item on other platforms.
+        #[cfg(target_os = "macos")]
+        assert_eq!(action_name(&menus[1].items[0]), "New Window");
+        #[cfg(not(target_os = "macos"))]
         assert_eq!(action_name(&menus[0].items[0]), "New Window");
 
         // Open Recent File submenu location differs by platform.
         #[cfg(target_os = "macos")]
         assert_eq!(
-            submenu(&menus[1].items[1]).name.to_string(),
+            submenu(&menus[1].items[2]).name.to_string(),
             "Open Recent File"
         );
         #[cfg(not(target_os = "macos"))]
@@ -1163,15 +1175,21 @@ mod tests {
 
         // Preferences location differs by platform.
         #[cfg(target_os = "macos")]
-        assert_eq!(action_name(&menus[0].items[1]), "Preferences");
+        assert_eq!(action_name(&menus[0].items[0]), "Preferences");
         #[cfg(not(target_os = "macos"))]
         assert_eq!(action_name(&menus[0].items[3]), "Preferences");
 
         assert_eq!(action_name(&menus[EXPORT_IDX].items[0]), "HTML");
         assert_eq!(action_name(&menus[EXPORT_IDX].items[1]), "PDF");
         assert_eq!(action_name(&menus[LANGUAGE_IDX].items[0]), "简体中文");
-        assert_eq!(action_name(&menus[LANGUAGE_IDX].items[1]), "\u{2713} English");
-        assert_eq!(action_name(&menus[WORKSPACE_IDX].items[0]), "Toggle Workspace");
+        assert_eq!(
+            action_name(&menus[LANGUAGE_IDX].items[1]),
+            "\u{2713} English"
+        );
+        assert_eq!(
+            action_name(&menus[WORKSPACE_IDX].items[0]),
+            "Toggle Workspace"
+        );
     }
 
     #[test]
@@ -1182,7 +1200,7 @@ mod tests {
 
         #[cfg(target_os = "macos")]
         assert_eq!(
-            submenu(&menus[1].items[1]).name.to_string(),
+            submenu(&menus[1].items[2]).name.to_string(),
             i18n_manager.strings().menu_open_recent_file.as_str()
         );
         #[cfg(not(target_os = "macos"))]
@@ -1207,10 +1225,16 @@ mod tests {
             vec!["文件", "导出", "语言", "主题", "工作区", "帮助"]
         );
 
+        #[cfg(target_os = "macos")]
+        assert_eq!(action_name(&menus[1].items[0]), "新建窗口");
+        #[cfg(not(target_os = "macos"))]
         assert_eq!(action_name(&menus[0].items[0]), "新建窗口");
         assert_eq!(action_name(&menus[EXPORT_IDX].items[0]), "HTML");
         assert_eq!(action_name(&menus[EXPORT_IDX].items[1]), "PDF");
-        assert_eq!(action_name(&menus[LANGUAGE_IDX].items[0]), "\u{2713} 简体中文");
+        assert_eq!(
+            action_name(&menus[LANGUAGE_IDX].items[0]),
+            "\u{2713} 简体中文"
+        );
         assert_eq!(action_name(&menus[LANGUAGE_IDX].items[1]), "English");
         assert_eq!(action_name(&menus[WORKSPACE_IDX].items[0]), "切换工作区");
     }
@@ -1260,10 +1284,10 @@ mod tests {
         let i18n_manager = I18nManager::default();
         let menus = build_menus(&theme_manager, &i18n_manager, &[]);
 
-        // On macOS: File menu is index 1, Open Recent is item 1 within it.
+        // On macOS: File menu is index 1, Open Recent is item 2 within it.
         // On other platforms: File menu is index 0, Open Recent is item 2.
         #[cfg(target_os = "macos")]
-        let recent_menu = submenu(&menus[1].items[1]);
+        let recent_menu = submenu(&menus[1].items[2]);
         #[cfg(not(target_os = "macos"))]
         let recent_menu = submenu(&menus[0].items[2]);
 
@@ -1289,7 +1313,7 @@ mod tests {
         let menus = build_menus(&theme_manager, &i18n_manager, &recent_files);
 
         #[cfg(target_os = "macos")]
-        let recent_menu = submenu(&menus[1].items[1]);
+        let recent_menu = submenu(&menus[1].items[2]);
         #[cfg(not(target_os = "macos"))]
         let recent_menu = submenu(&menus[0].items[2]);
 


### PR DESCRIPTION
This PR fixes issue #52. On macOS the first menu bar item is always renamed to the Applications name even if its name is set as `File`. On macOS it is a convention to have `Settings` and `Quit Application` on this first menu bar item whereas `Open File`, `Open Recent File`, `Save` and `Save As` should go into a second item called `File`. This PR creates this menu bar structure on macOS and keeps the old menu bar structure for other platforms. The test suite for the `app_menu` was also was also adjusted to differentiate between the different menu structures for macOS and other platforms.