### PR TITLE
Fixed code block bug and added ability to close them in rendered mode…

### DIFF
--- a/src/components/block/interactions.rs
+++ b/src/components/block/interactions.rs
@@ -202,6 +202,18 @@ impl Block {
         }
     }
 
+    /// If the code block's last line is a bare fence (three or more backticks
+    /// or tildes, no info string), returns the byte offset to cut from so the
+    /// whole line is removed; otherwise `None`.
+    fn trailing_code_fence_line_start(&self) -> Option<usize> {
+        let text = self.display_text();
+        let line_start = text.rfind('\n').map(|idx| idx + 1).unwrap_or(0);
+        let is_bare_fence = BlockKind::parse_code_fence_opening(&text[line_start..])
+            .is_some_and(|fence| fence.language.is_none());
+        // Cut from the preceding newline too, unless the fence is the only line.
+        is_bare_fence.then(|| line_start.saturating_sub(1))
+    }
+
     pub(crate) fn on_newline(&mut self, _: &Newline, window: &mut Window, cx: &mut Context<Self>) {
         // Enter is ordered from special editors to rich-text splitting:
         // table/source/code/quote-like blocks keep local newline semantics,
@@ -305,6 +317,21 @@ impl Block {
         if self.kind().is_code_block() {
             if self.selected_range.is_empty() && self.is_empty() {
                 self.convert_to_paragraph(cx);
+                return;
+            }
+            // Typing a bare closing fence on the last line and pressing Enter
+            // leaves the block, matching source mode.
+            if self.selected_range.is_empty()
+                && self.cursor_offset() == self.visible_len()
+                && let Some(fence_start) = self.trailing_code_fence_line_start()
+            {
+                let fence_end = self.visible_len();
+                self.prepare_undo_capture(UndoCaptureKind::NonCoalescible, cx);
+                self.replace_text_in_visible_range(fence_start..fence_end, "", None, false, cx);
+                cx.emit(BlockEvent::RequestNewline {
+                    trailing: InlineTextTree::plain(String::new()),
+                    source_already_mutated: true,
+                });
                 return;
             }
             if !self.selected_range.is_empty() {

--- a/src/editor/document.rs
+++ b/src/editor/document.rs
@@ -166,6 +166,13 @@ fn find_matching_closing_fence(
     for index in (start_index + 1)..lines.len() {
         let line = &lines[index];
         if is_closing_fence(line, opener) {
+            // An empty opener looks identical to a closing fence, so the
+            // greedy search below would merge adjacent empty-language blocks
+            // (issue #58). Close at the first match instead; greedy matching
+            // is only needed for info-tagged blocks that may wrap bare fences.
+            if opener.language.is_none() {
+                return Some(index);
+            }
             last_match = Some(index);
             continue;
         }
@@ -1876,6 +1883,22 @@ mod tests {
         ];
         let opener = parse_opening_fence(&lines[0]).expect("opening fence");
         assert_eq!(find_matching_closing_fence(&lines, 0, &opener), Some(3));
+    }
+
+    #[test]
+    fn empty_language_fence_closes_at_first_match() {
+        // Adjacent empty-language blocks must stay separate rather than the
+        // first absorbing the second's fences as body content (issue #58).
+        let lines = vec![
+            "```".to_string(),
+            "first".to_string(),
+            "```".to_string(),
+            "```".to_string(),
+            "second".to_string(),
+            "```".to_string(),
+        ];
+        let opener = parse_opening_fence(&lines[0]).expect("opening fence");
+        assert_eq!(find_matching_closing_fence(&lines, 0, &opener), Some(2));
     }
 
     #[test]

--- a/src/editor/events.rs
+++ b/src/editor/events.rs
@@ -1849,6 +1849,44 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn trailing_fence_line_enter_closes_code_block(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let editor =
+            cx.new(|cx| Editor::from_markdown(cx, "```rust\nlet x = 1;\n```".to_string(), None));
+
+        cx.update(|window, cx| {
+            editor.update(cx, |editor, cx| {
+                let block = editor.document.visible_blocks()[0].entity.clone();
+                block.update(cx, |block, block_cx| {
+                    // Type a closing fence on a fresh last line, then Enter.
+                    let end = block.visible_len();
+                    block.replace_text_in_visible_range(end..end, "\n```", None, false, block_cx);
+                    block.move_to(block.visible_len(), block_cx);
+                    block.on_newline(&Newline, window, block_cx);
+                });
+            });
+        });
+
+        editor.update(cx, |editor, cx| {
+            let visible = editor.document.visible_blocks();
+            assert_eq!(visible.len(), 2);
+            assert_eq!(
+                visible[0].entity.read(cx).kind(),
+                BlockKind::CodeBlock {
+                    language: Some("rust".into())
+                }
+            );
+            assert_eq!(visible[0].entity.read(cx).display_text(), "let x = 1;");
+            assert_eq!(visible[1].entity.read(cx).kind(), BlockKind::Paragraph);
+            assert_eq!(visible[1].entity.read(cx).display_text(), "");
+            assert_eq!(
+                editor.document.markdown_text(cx),
+                "```rust\nlet x = 1;\n```\n\n"
+            );
+        });
+    }
+
+    #[gpui::test]
     async fn math_block_exit_shortcut_creates_plain_text_block(cx: &mut TestAppContext) {
         let cx = cx.add_empty_window();
         let editor = cx.new(|cx| Editor::from_markdown(cx, "$$n^2$$".to_string(), None));


### PR DESCRIPTION
The main code block issue has been fixed, and I added the ability to close code blocks without a shortcut.

All changes are confined to the existing parser/runtime model. No new dependencies.

Unit tests have been added.

## Code block issues and their fixes

**Adjacent empty-language code blocks were merged (issue #58).**
- A code block with no language specifier consumed later blocks' fences instead of closing at first matching fence. The absorbed ` ``` ` lines forced a tilde fence, so the blocks lost their formatting and their ` ``` ` delimiters turned into `~~~`.
- **The fix:** `find_matching_closing_fence()` now closes at the first matching fence when the opener has no language, matching CommonMark. The greedy outermost-match search is kept for info-tagged blocks, whose bodies may legitimately contain bare fence lines.
    
**No intuitive way to close a code block from last line in rendered mode.**
- If a code block is the last block in the document, the caret seems trapped in rendered mode. Source mode allowed it, but requiring this for something this basic undercuts the WYSIWYG workflow. There is a shortcut for exiting code blocks/tables, but many users will miss this.
- **The fix:** Now in rendered mode, typing a bare fence (` ``` ` or `~~~`) on a code block's last line and pressing Enter strips that line and moves the caret to a new paragraph below, matching source mode. This also aligns with how many users are accustomed to closing code blocks in other Markdown editors. Exiting with the Down arrow when a line already exists below is unchanged.