### PR TITLE
chore(release): bump velotype version and repository field

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6892,7 +6892,7 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "velotype"
-version = "0.5.3"
+version = "0.5.7"
 dependencies = [
  "adot-tree-sitter-toml",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "velotype"
-version = "0.5.3"
+version = "0.5.7"
 edition = "2024"
+repository = "https://github.com/manyougz/velotype"
 license = "Apache-2.0"
 
 [lints.clippy]


### PR DESCRIPTION
velotype version: 0.5.3 -> 0.5.7