### PR TITLE
fix(macos): open files passed by Finder (#66)

### DIFF
--- a/src/app_menu.rs
+++ b/src/app_menu.rs
@@ -78,7 +78,7 @@ pub(crate) fn open_editor_window(
     handle
 }
 
-fn open_file_in_new_window(cx: &mut App, path: &Path) -> anyhow::Result<()> {
+pub(crate) fn open_file_in_new_window(cx: &mut App, path: &Path) -> anyhow::Result<()> {
     let markdown = std::fs::read_to_string(path)
         .with_context(|| format!("failed to read '{}'", path.display()))?;
     open_editor_window(cx, markdown, Some(path.to_path_buf()));

--- a/src/file_url.rs
+++ b/src/file_url.rs
@@ -1,0 +1,105 @@
+//! File URL parsing for platform open-file events.
+
+use std::path::PathBuf;
+
+/// Parses a local file URL into a path.
+///
+/// GPUI's macOS `on_open_urls` callback provides `file://` URLs, while tests
+/// and other callers may pass plain paths. Only local `file://` URLs are
+/// accepted; non-file schemes and remote file authorities are rejected.
+pub(crate) fn parse_file_url(value: &str) -> Option<PathBuf> {
+    if let Some(rest) = value.strip_prefix("file://") {
+        let path = if let Some(path) = rest.strip_prefix("localhost/") {
+            format!("/{path}")
+        } else if rest.starts_with('/') {
+            rest.to_string()
+        } else {
+            return None;
+        };
+
+        return percent_decode(&path).map(PathBuf::from);
+    }
+
+    if value.contains("://") {
+        return None;
+    }
+
+    Some(PathBuf::from(value))
+}
+
+fn percent_decode(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            let hi = bytes.get(i + 1).copied().and_then(hex_value)?;
+            let lo = bytes.get(i + 2).copied().and_then(hex_value)?;
+            decoded.push((hi << 4) | lo);
+            i += 3;
+        } else {
+            decoded.push(bytes[i]);
+            i += 1;
+        }
+    }
+
+    String::from_utf8(decoded).ok()
+}
+
+fn hex_value(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_file_url;
+    use std::path::PathBuf;
+
+    #[test]
+    fn parses_file_url_with_spaces() {
+        assert_eq!(
+            parse_file_url("file:///Users/example/My%20Notes/test%20file.md"),
+            Some(PathBuf::from("/Users/example/My Notes/test file.md"))
+        );
+    }
+
+    #[test]
+    fn parses_file_url_with_unicode() {
+        assert_eq!(
+            parse_file_url("file:///Users/example/Notes/%E2%9C%93-%E6%96%87.md"),
+            Some(PathBuf::from("/Users/example/Notes/✓-文.md"))
+        );
+    }
+
+    #[test]
+    fn parses_localhost_authority() {
+        assert_eq!(
+            parse_file_url("file://localhost/Users/example/test.md"),
+            Some(PathBuf::from("/Users/example/test.md"))
+        );
+    }
+
+    #[test]
+    fn rejects_non_file_scheme() {
+        assert_eq!(parse_file_url("https://example.com/test.md"), None);
+    }
+
+    #[test]
+    fn passes_plain_path_through() {
+        assert_eq!(
+            parse_file_url("notes/100% literal.md"),
+            Some(PathBuf::from("notes/100% literal.md"))
+        );
+    }
+
+    #[test]
+    fn rejects_remote_file_authority() {
+        assert_eq!(parse_file_url("file://example.com/share/test.md"), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,14 @@
 
 use std::borrow::Cow;
 use std::path::PathBuf;
+#[cfg(target_os = "macos")]
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
+#[cfg(target_os = "macos")]
+use futures::{StreamExt, channel::mpsc};
 use gpui::*;
 
 mod app_identity;
@@ -16,6 +23,8 @@ mod components;
 mod config;
 mod editor;
 mod export;
+#[cfg(any(target_os = "macos", test))]
+mod file_url;
 mod i18n;
 mod net;
 mod theme;
@@ -23,10 +32,33 @@ mod window_chrome;
 
 use app_menu::{init as init_app_menu, open_editor_window};
 use components::init_with_keybindings as init_editor;
+#[cfg(target_os = "macos")]
+use file_url::parse_file_url;
 use i18n::I18nManager;
 use theme::ThemeManager;
 
 struct VelotypeAssets;
+
+fn open_startup_window(cx: &mut App, startup_open: config::StartupOpenPreference) {
+    if startup_open == config::StartupOpenPreference::LastOpenedFile
+        && let Some(path) = config::first_existing_recent_markdown_file()
+    {
+        match std::fs::read_to_string(&path) {
+            Ok(markdown) => {
+                open_editor_window(cx, markdown, Some(path));
+                return;
+            }
+            Err(err) => {
+                eprintln!(
+                    "failed to read last opened file '{}': {err}",
+                    path.display()
+                );
+            }
+        }
+    }
+
+    open_editor_window(cx, String::new(), None);
+}
 
 impl AssetSource for VelotypeAssets {
     fn load(&self, path: &str) -> gpui::Result<Option<Cow<'static, [u8]>>> {
@@ -130,68 +162,100 @@ fn main() {
         return;
     }
 
-    Application::new()
-        .with_assets(VelotypeAssets)
-        .run(move |cx: &mut App| {
-            let preferences = config::load_or_create_app_preferences().unwrap_or_else(|err| {
-                eprintln!("failed to initialize app preferences: {err}");
-                Default::default()
-            });
-            I18nManager::init_with_language_id(cx, &preferences.default_language_id);
-            ThemeManager::init_with_theme_id(cx, &preferences.default_theme_id);
-            net::install_http_client(cx);
-            init_editor(cx, &preferences.keybindings);
-            init_app_menu(cx);
+    #[cfg(target_os = "macos")]
+    let (open_file_tx, mut open_file_rx) = mpsc::unbounded::<PathBuf>();
+    #[cfg(target_os = "macos")]
+    let open_file_requested = Arc::new(AtomicBool::new(false));
 
-            if input_paths.is_empty() {
-                if preferences.startup_open == config::StartupOpenPreference::LastOpenedFile
-                    && let Some(path) = config::first_existing_recent_markdown_file()
-                {
-                    match std::fs::read_to_string(&path) {
-                        Ok(markdown) => {
-                            open_editor_window(cx, markdown, Some(path));
-                            return;
-                        }
-                        Err(err) => {
-                            eprintln!(
-                                "failed to read last opened file '{}': {err}",
-                                path.display()
-                            );
-                        }
-                    }
-                }
-                open_editor_window(cx, String::new(), None);
-                return;
-            }
+    let app = Application::new().with_assets(VelotypeAssets);
 
-            for path in &input_paths {
-                let absolute_path = if path.is_absolute() {
-                    path.clone()
-                } else {
-                    match std::env::current_dir() {
-                        Ok(cwd) => cwd.join(path),
-                        Err(_) => path.clone(),
-                    }
+    #[cfg(target_os = "macos")]
+    {
+        let open_file_requested_for_callback = open_file_requested.clone();
+        app.on_open_urls(move |urls| {
+            for url in urls {
+                let Some(path) = parse_file_url(&url) else {
+                    continue;
                 };
-
-                let markdown = match std::fs::read_to_string(&absolute_path) {
-                    Ok(content) => {
-                        if let Err(err) = config::record_recent_file(&absolute_path) {
-                            eprintln!("failed to update recent file history: {err}");
-                        }
-                        content
-                    }
-                    Err(err) => {
-                        eprintln!(
-                            "failed to read '{}': {err}. opened as empty document.",
-                            absolute_path.display()
-                        );
-                        String::new()
-                    }
-                };
-                open_editor_window(cx, markdown, Some(absolute_path));
+                open_file_requested_for_callback.store(true, Ordering::SeqCst);
+                let _ = open_file_tx.unbounded_send(path);
             }
-            app_menu::install_menus(cx);
-            cx.refresh_windows();
         });
+    }
+
+    app.run(move |cx: &mut App| {
+        let preferences = config::load_or_create_app_preferences().unwrap_or_else(|err| {
+            eprintln!("failed to initialize app preferences: {err}");
+            Default::default()
+        });
+        I18nManager::init_with_language_id(cx, &preferences.default_language_id);
+        ThemeManager::init_with_theme_id(cx, &preferences.default_theme_id);
+        net::install_http_client(cx);
+        init_editor(cx, &preferences.keybindings);
+        init_app_menu(cx);
+
+        #[cfg(target_os = "macos")]
+        cx.spawn(async move |cx| {
+            while let Some(path) = open_file_rx.next().await {
+                let _ = cx.update(move |cx| {
+                    if let Err(err) = app_menu::open_file_in_new_window(cx, &path) {
+                        eprintln!("failed to open '{}': {err}", path.display());
+                    }
+                });
+            }
+        })
+        .detach();
+
+        if input_paths.is_empty() {
+            #[cfg(target_os = "macos")]
+            {
+                let startup_open = preferences.startup_open;
+                let open_file_requested = open_file_requested.clone();
+                cx.spawn(async move |cx| {
+                    cx.background_executor()
+                        .timer(std::time::Duration::from_millis(150))
+                        .await;
+                    if !open_file_requested.load(Ordering::SeqCst) {
+                        let _ = cx.update(move |cx| open_startup_window(cx, startup_open));
+                    }
+                })
+                .detach();
+            }
+
+            #[cfg(not(target_os = "macos"))]
+            open_startup_window(cx, preferences.startup_open);
+
+            return;
+        }
+
+        for path in &input_paths {
+            let absolute_path = if path.is_absolute() {
+                path.clone()
+            } else {
+                match std::env::current_dir() {
+                    Ok(cwd) => cwd.join(path),
+                    Err(_) => path.clone(),
+                }
+            };
+
+            let markdown = match std::fs::read_to_string(&absolute_path) {
+                Ok(content) => {
+                    if let Err(err) = config::record_recent_file(&absolute_path) {
+                        eprintln!("failed to update recent file history: {err}");
+                    }
+                    content
+                }
+                Err(err) => {
+                    eprintln!(
+                        "failed to read '{}': {err}. opened as empty document.",
+                        absolute_path.display()
+                    );
+                    String::new()
+                }
+            };
+            open_editor_window(cx, markdown, Some(absolute_path));
+        }
+        app_menu::install_menus(cx);
+        cx.refresh_windows();
+    });
 }


### PR DESCRIPTION
# Fix(macos): open files passed by Finder (#66)

## Summary

This fixes macOS Finder launches for markdown files registered to Velotype.

On macOS, double-clicking a document does not pass the file path through `argv`; Finder sends an `application:openURLs:` event instead. Velotype already declares the markdown document type in `Info.plist`, but the app only read paths from command-line arguments, so Finder launches opened the startup/empty window instead of the selected file.

This PR:

- registers GPUI's `Application::on_open_urls` on macOS before `run()`
- decodes local `file://` URLs into paths without adding a new dependency
- routes Finder-opened files through the existing app-menu open-file path so recent files and menus stay in sync
- defers the macOS no-argv startup window briefly, so the cold-launch open-file event can arrive before Velotype opens a blank window
- keeps non-macOS startup behavior unchanged

## Notes

The small channel bridge is needed because GPUI's `on_open_urls` callback receives only `Vec<String>` URLs and no `&mut App`, so it cannot open editor windows directly from the callback.

The deferred startup fallback is macOS-only. It preserves normal empty launches, but avoids creating an extra blank window when Finder sends a file-open event just after app launch.

Prepared with AI assistance and manually reviewed/tested locally.

## Testing

- `cargo fmt`
- `cargo test file_url`
- `cargo build`
- `cargo clippy --all-targets --all-features`
  - completes with existing warnings in unrelated code paths
- `./scripts/create_macos_app_dist.sh`
- Manual macOS QA with `dist/Velotype.app`:
  - set the built app as the default handler for a markdown file
  - double-clicked a markdown file from Finder
  - expected result: selected file opens in Velotype, with no extra blank window

