### PR TITLE
Fixes for links and inline math

### DIFF
--- a/src/components/block/element.rs
+++ b/src/components/block/element.rs
@@ -1161,10 +1161,10 @@ impl Element for BlockTextElement {
         window: &mut Window,
         cx: &mut App,
     ) {
-        let (focus_handle, hovered_link) = {
+        let (focus_handle, hovering_link) = {
             let input = self.input.read(cx);
             let text_bounds = source_text_bounds(bounds, prepaint.source_line_number_gutter_width);
-            let hovered_link = !self.is_placeholder
+            let hovering_link = !self.is_placeholder
                 && !input.is_source_raw_mode()
                 && prepaint.hitbox.is_hovered(window)
                 && link_at_position(
@@ -1175,11 +1175,17 @@ impl Element for BlockTextElement {
                     window.mouse_position(),
                 )
                 .is_some();
-            (input.focus_handle.clone(), hovered_link)
+            (input.focus_handle.clone(), hovering_link)
         };
 
-        if hovered_link {
-            window.set_cursor_style(CursorStyle::PointingHand, &prepaint.hitbox);
+        if hovering_link {
+            // The hand cursor only appears while the Cmd/Ctrl follow modifier is
+            // held (matching the gesture that opens the link); a plain hover keeps
+            // the text cursor. The editor root repaints on follow-modifier
+            // toggles, so this re-evaluates even when the pointer stays still.
+            if window.modifiers().secondary() {
+                window.set_cursor_style(CursorStyle::PointingHand, &prepaint.hitbox);
+            }
         }
 
         if focus_handle.is_focused(window) {
@@ -1259,8 +1265,8 @@ mod tests {
     };
     use crate::components::{Block, BlockKind, BlockRecord, InlineTextTree, TableCellPosition};
     use gpui::{
-        AppContext, Bounds, Hsla, SharedString, TestAppContext, TextAlign, TextRun,
-        VisualTestContext, font, point, px, rgba, size,
+        AppContext, Bounds, Hsla, Modifiers, MouseButton, MouseDownEvent, SharedString,
+        TestAppContext, TextAlign, TextRun, VisualTestContext, font, point, px, rgba, size,
     };
 
     fn shaped_lines(
@@ -1370,6 +1376,75 @@ mod tests {
 
         assert_eq!(hit, Some("https://example.com".to_string()));
         assert_eq!(miss_right, None);
+    }
+
+    #[gpui::test]
+    async fn secondary_click_follows_link_while_plain_click_edits(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let block = cx.new(|cx| {
+            Block::with_record(
+                cx,
+                BlockRecord::new(
+                    BlockKind::Paragraph,
+                    InlineTextTree::from_markdown("a [link](https://example.com) bbbb"),
+                ),
+            )
+        });
+
+        let display_text = block.read_with(cx, |block, _cx| block.display_text().to_string());
+        let lines = shaped_lines(&display_text, px(320.0), cx);
+        let bounds = Bounds::new(point(px(0.0), px(0.0)), size(px(320.0), px(20.0)));
+
+        let link_position = block.read_with(cx, |block, _cx| {
+            let span = block
+                .inline_spans()
+                .iter()
+                .find(|span| span.link.is_some())
+                .expect("link span should exist");
+            let layout = &lines[0];
+            let start = layout
+                .position_for_index(span.range.start, px(20.0))
+                .expect("start position");
+            let end = layout
+                .position_for_index(span.range.end, px(20.0))
+                .expect("end position");
+            point((start.x + end.x) / 2.0, px(10.0))
+        });
+
+        block.update(cx, |block, _cx| {
+            block.last_layout = Some(lines.clone());
+            block.last_bounds = Some(bounds);
+            block.last_line_height = px(20.0);
+            block.selected_range = 0..0;
+        });
+
+        let mut event = MouseDownEvent {
+            button: MouseButton::Left,
+            position: link_position,
+            modifiers: Modifiers::default(),
+            click_count: 1,
+            first_mouse: false,
+        };
+
+        // A plain click on the link moves the caret into the text for editing.
+        cx.update(|window, app| {
+            block.update(app, |block, cx| block.on_mouse_down(&event, window, cx));
+        });
+        block.read_with(cx, |block, _cx| {
+            assert_ne!(block.selected_range, 0..0);
+        });
+
+        // Cmd/Ctrl+click follows the link instead: the caret is left untouched
+        // and no drag-selection begins.
+        block.update(cx, |block, _cx| block.selected_range = 0..0);
+        event.modifiers = Modifiers::secondary_key();
+        cx.update(|window, app| {
+            block.update(app, |block, cx| block.on_mouse_down(&event, window, cx));
+        });
+        block.read_with(cx, |block, _cx| {
+            assert_eq!(block.selected_range, 0..0);
+            assert!(!block.is_selecting);
+        });
     }
 
     #[gpui::test]

--- a/src/components/block/interactions.rs
+++ b/src/components/block/interactions.rs
@@ -233,18 +233,6 @@ impl Block {
             return;
         }
 
-        if self.inline_math_source_editing() {
-            self.prepare_undo_capture(UndoCaptureKind::NonCoalescible, cx);
-            if let Some(trailing) = self.split_inline_math_source_edit_for_newline() {
-                self.mark_changed(cx);
-                cx.emit(BlockEvent::RequestNewline {
-                    trailing,
-                    source_already_mutated: true,
-                });
-            }
-            return;
-        }
-
         if self.is_source_raw_mode() {
             if !self.selected_range.is_empty() {
                 self.replace_text_in_range(None, "", window, cx);
@@ -266,12 +254,18 @@ impl Block {
             return;
         }
 
+        // `$$` then Enter opens a display-math block. Keying off the caret sitting
+        // right after a leading `$$` (rather than the line being exactly `$$`)
+        // means it also fires after pressing Home on an existing line and typing
+        // the fence in front of a formula: the rest of the line becomes the math
+        // body instead of being split off into a new paragraph.
         if self.kind() == BlockKind::Paragraph
             && self.selected_range.is_empty()
-            && self.cursor_offset() == self.visible_len()
-            && self.display_text() == "$$"
+            && self.cursor_offset() == "$$".len()
+            && self.display_text().starts_with("$$")
         {
-            self.enter_math_block(cx);
+            let body = self.display_text()["$$".len()..].to_string();
+            self.enter_math_block(&body, cx);
             return;
         }
 
@@ -1275,6 +1269,14 @@ impl Block {
         let offset = self.index_for_mouse_position(event.position);
         let was_focused = self.focus_handle.is_focused(window);
 
+        // Cmd/Ctrl+click follows a rendered link instead of editing it, so the
+        // block is neither focused nor selected; the link opens on mouse-up.
+        if event.modifiers.secondary() && self.pointer_link_hit(event.position).is_some() {
+            self.is_selecting = false;
+            cx.stop_propagation();
+            return;
+        }
+
         if was_focused {
             self.is_selecting = true;
             if event.modifiers.shift {
@@ -1289,6 +1291,54 @@ impl Block {
         }
     }
 
+    /// Resolve the inline link under a pointer position against the most recent
+    /// rendered text layout, if any. Returns `None` while the block shows raw
+    /// source or when the pointer is not over a link.
+    pub(crate) fn pointer_link_hit(&self, position: Point<Pixels>) -> Option<super::InlineLinkHit> {
+        self.last_layout
+            .as_ref()
+            .zip(self.last_bounds)
+            .and_then(|(lines, bounds)| {
+                super::element::link_at_position(
+                    self,
+                    lines,
+                    bounds,
+                    self.last_line_height,
+                    position,
+                )
+            })
+            .cloned()
+    }
+
+    /// Handle mouse-down on a rendered inline link (in a mixed inline-visual
+    /// block). A Cmd/Ctrl+click is claimed here so it follows the link instead
+    /// of focusing the block; the destination opens on the matching mouse-up.
+    pub(crate) fn on_rendered_link_mouse_down(
+        &mut self,
+        event: &MouseDownEvent,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        // Only Cmd/Ctrl+click follows the link; a plain click falls through so
+        // the block focuses for editing like any other inline text.
+        if event.modifiers.secondary() {
+            cx.stop_propagation();
+        }
+    }
+
+    /// Open a rendered inline link's destination through the editor prompt.
+    pub(crate) fn open_rendered_link(
+        &mut self,
+        link: &super::InlineLinkHit,
+        cx: &mut Context<Self>,
+    ) {
+        cx.stop_propagation();
+        cx.emit(BlockEvent::RequestOpenLink {
+            prompt_target: link.prompt_target.clone(),
+            open_target: link.open_target.clone(),
+        });
+    }
+
     pub(crate) fn on_mouse_up(
         &mut self,
         event: &MouseUpEvent,
@@ -1296,6 +1346,16 @@ impl Block {
         cx: &mut Context<Self>,
     ) {
         self.is_selecting = false;
+
+        // Cmd/Ctrl+click follows a rendered link, using the same open-link
+        // prompt as the double-click gesture below.
+        if event.modifiers.secondary()
+            && let Some(link) = self.pointer_link_hit(event.position)
+        {
+            self.open_rendered_link(&link, cx);
+            return;
+        }
+
         if event.click_count >= 2 {
             let footnote = self
                 .last_layout
@@ -1317,26 +1377,8 @@ impl Block {
                 return;
             }
 
-            let link = self
-                .last_layout
-                .as_ref()
-                .zip(self.last_bounds)
-                .and_then(|(lines, bounds)| {
-                    super::element::link_at_position(
-                        self,
-                        lines,
-                        bounds,
-                        self.last_line_height,
-                        event.position,
-                    )
-                })
-                .cloned();
-            if let Some(link) = link {
-                cx.stop_propagation();
-                cx.emit(BlockEvent::RequestOpenLink {
-                    prompt_target: link.prompt_target,
-                    open_target: link.open_target,
-                });
+            if let Some(link) = self.pointer_link_hit(event.position) {
+                self.open_rendered_link(&link, cx);
             }
         }
     }

--- a/src/components/block/render.rs
+++ b/src/components/block/render.rs
@@ -675,7 +675,7 @@ impl Block {
             };
         }
 
-        self.render_mixed_inline_visual_runs(theme, text_color, font_size, font_weight)
+        self.render_mixed_inline_visual_runs(theme, text_color, font_size, font_weight, cx)
     }
 
     fn render_mixed_inline_visual_runs(
@@ -684,6 +684,7 @@ impl Block {
         base_color: Hsla,
         font_size: f32,
         font_weight: FontWeight,
+        cx: &mut Context<Self>,
     ) -> AnyElement {
         self.render_inline_tree_runs(
             &self.record.title,
@@ -691,6 +692,7 @@ impl Block {
             base_color,
             font_size,
             font_weight,
+            cx,
         )
     }
 
@@ -701,6 +703,7 @@ impl Block {
         base_color: Hsla,
         font_size: f32,
         font_weight: FontWeight,
+        cx: &mut Context<Self>,
     ) -> AnyElement {
         div()
             .w_full()
@@ -717,6 +720,7 @@ impl Block {
                 base_color,
                 font_size,
                 font_weight,
+                cx,
             ))
             .into_any_element()
     }
@@ -728,6 +732,7 @@ impl Block {
         base_color: Hsla,
         font_size: f32,
         font_weight: FontWeight,
+        cx: &mut Context<Self>,
     ) -> Vec<AnyElement> {
         let cache = tree.render_cache();
         let text = cache.visible_text();
@@ -736,29 +741,39 @@ impl Block {
 
         for span in cache.spans() {
             if cursor < span.range.start {
-                children.push(self.render_inline_text_segment(
+                let fallback_span = crate::components::InlineSpan {
+                    range: cursor..span.range.start,
+                    style: crate::components::InlineStyle::default(),
+                    html_style: None,
+                    link: None,
+                    footnote: None,
+                    math: None,
+                };
+                children.extend(self.render_inline_text_word_segments(
                     &text[cursor..span.range.start],
-                    span,
+                    &fallback_span,
                     theme,
                     base_color,
                     font_size,
                     font_weight,
+                    cx,
                 ));
             }
 
             let span_text = &text[span.range.clone()];
             if let Some(math) = span.math.as_ref() {
                 children.push(
-                    self.render_inline_math_segment(math, span, theme, base_color, font_size),
+                    self.render_inline_math_segment(math, span, theme, base_color, font_size, cx),
                 );
             } else {
-                children.push(self.render_inline_text_segment(
+                children.extend(self.render_inline_text_word_segments(
                     span_text,
                     span,
                     theme,
                     base_color,
                     font_size,
                     font_weight,
+                    cx,
                 ));
             }
             cursor = span.range.end;
@@ -773,17 +788,53 @@ impl Block {
                 footnote: None,
                 math: None,
             };
-            children.push(self.render_inline_text_segment(
+            children.extend(self.render_inline_text_word_segments(
                 &text[cursor..],
                 &fallback_span,
                 theme,
                 base_color,
                 font_size,
                 font_weight,
+                cx,
             ));
         }
 
         children
+    }
+
+    /// Split a styled text run into wrap-friendly word segments. The mixed
+    /// inline-visual layout is a `flex_wrap` row, so a long run rendered as one
+    /// element wraps internally and claims the full row width, pushing the next
+    /// item (inline math, a script, ...) onto its own line. Emitting one element
+    /// per whitespace-delimited word lets the row break between words and keeps
+    /// adjacent visuals on the same visual line. Inline code and background
+    /// highlights stay a single element so their pill/background is continuous.
+    fn render_inline_text_word_segments(
+        &self,
+        text: &str,
+        span: &crate::components::InlineSpan,
+        theme: &Theme,
+        base_color: Hsla,
+        font_size: f32,
+        font_weight: FontWeight,
+        cx: &mut Context<Self>,
+    ) -> Vec<AnyElement> {
+        let has_background = span
+            .html_style
+            .is_some_and(|style| style.background_color.is_some());
+        let mut segments = Vec::new();
+        for word in inline_word_chunks(text, span.style.code, has_background) {
+            segments.push(self.render_inline_text_segment(
+                word,
+                span,
+                theme,
+                base_color,
+                font_size,
+                font_weight,
+                cx,
+            ));
+        }
+        segments
     }
 
     fn render_inline_text_segment(
@@ -794,6 +845,7 @@ impl Block {
         base_color: Hsla,
         font_size: f32,
         font_weight: FontWeight,
+        cx: &mut Context<Self>,
     ) -> AnyElement {
         if text.is_empty() {
             return div().into_any_element();
@@ -856,6 +908,33 @@ impl Block {
                 .bg(html_css_color_to_hsla(background, color));
         }
 
+        // This run renders as plain (non-interactive) text, so a link inside a
+        // mixed inline-visual block (alongside math or a script) would otherwise
+        // have no way to be followed. Attach the open-link handlers directly to
+        // the segment; they act only on Cmd/Ctrl+click so a plain click still
+        // falls through and focuses the block for editing. The wrapper element
+        // gates the hand cursor on that same modifier, matching the normal-text
+        // path where links render through `BlockTextElement`.
+        if let Some(link) = span.link.clone() {
+            let element = element
+                .on_mouse_down(
+                    MouseButton::Left,
+                    cx.listener(Self::on_rendered_link_mouse_down),
+                )
+                .on_mouse_up(
+                    MouseButton::Left,
+                    cx.listener(move |block, event: &MouseUpEvent, _window, cx| {
+                        if event.modifiers.secondary() {
+                            block.open_rendered_link(&link, cx);
+                        }
+                    }),
+                );
+            return LinkFollowCursor {
+                child: element.into_any_element(),
+            }
+            .into_any_element();
+        }
+
         element.into_any_element()
     }
 
@@ -866,6 +945,7 @@ impl Block {
         theme: &Theme,
         base_color: Hsla,
         font_size: f32,
+        cx: &mut Context<Self>,
     ) -> AnyElement {
         let mut color = base_color;
         if let Some(style) = span.html_style
@@ -892,6 +972,7 @@ impl Block {
                 base_color,
                 font_size,
                 FontWeight::NORMAL,
+                cx,
             ),
         }
     }
@@ -954,6 +1035,7 @@ impl Block {
         theme: &Theme,
         strings: &I18nStrings,
         font_weight: FontWeight,
+        cx: &mut Context<Self>,
     ) -> Option<AnyElement> {
         let segments = parse_table_cell_inline_images(&self.record.title.serialize_markdown());
         if !segments
@@ -977,6 +1059,7 @@ impl Block {
                         theme.colors.text_default,
                         theme.typography.text_size,
                         font_weight,
+                        cx,
                     ));
                 }
                 TableCellInlineImageSegment::Image { markdown, syntax } => {
@@ -990,6 +1073,7 @@ impl Block {
                             theme.colors.text_default,
                             theme.typography.text_size,
                             font_weight,
+                            cx,
                         ));
                     }
                 }
@@ -1562,12 +1646,11 @@ impl Render for Block {
         }
 
         let showing_rendered_image = self.showing_rendered_image();
-        if self.sync_inline_math_source_edit_for_focus(focused && !showing_rendered_image) {
-            cx.notify();
-        }
-        self.sync_inline_projection_for_focus(
-            focused && !showing_rendered_image && !self.inline_math_source_editing(),
-        );
+        // Inline math stays in the projected view while focused (its `$...$`
+        // source shows as editable text), so links and other styling in the same
+        // block keep their attributes instead of collapsing to raw Markdown, the
+        // same way script spans already behave.
+        self.sync_inline_projection_for_focus(focused && !showing_rendered_image);
 
         if input_active && self.cursor_blink_task.is_none() {
             self.start_cursor_blink(cx);
@@ -1673,6 +1756,7 @@ impl Render for Block {
                     } else {
                         FontWeight::NORMAL
                     },
+                    cx,
                 )
             {
                 return cell_base.child(inline_images).into_any_element();
@@ -2875,9 +2959,100 @@ impl Render for Block {
     }
 }
 
+/// Break a styled inline text run into wrap-friendly chunks for the mixed
+/// inline-visual layout. Runs that carry their own box (inline code, background
+/// highlight) stay a single chunk so their padding/background is continuous;
+/// everything else is split on whitespace with each word keeping its trailing
+/// space, so the `flex_wrap` row can break between words instead of pushing the
+/// next inline visual onto its own line.
+/// Wraps a rendered inline link run so the hand cursor only appears while the
+/// Cmd/Ctrl follow modifier is held. Links in mixed inline-visual blocks (math,
+/// scripts, inline images) render as plain divs, so this sets `PointingHand`
+/// when its hitbox is hovered and the modifier is down, like `BlockTextElement`
+/// does for normal text. The editor root repaints on follow-modifier toggles,
+/// so the cursor re-evaluates without the pointer moving. Layout and painting
+/// are delegated to the child.
+struct LinkFollowCursor {
+    child: AnyElement,
+}
+
+impl IntoElement for LinkFollowCursor {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for LinkFollowCursor {
+    type RequestLayoutState = ();
+    type PrepaintState = Hitbox;
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        (self.child.request_layout(window, cx), ())
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Self::PrepaintState {
+        self.child.prepaint(window, cx);
+        window.insert_hitbox(bounds, HitboxBehavior::Normal)
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        hitbox: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        if hitbox.is_hovered(window) && window.modifiers().secondary() {
+            // The editor root repaints on follow-modifier toggles, so the hand
+            // cursor re-evaluates here even while the pointer stays still.
+            window.set_cursor_style(CursorStyle::PointingHand, hitbox);
+        }
+        self.child.paint(window, cx);
+    }
+}
+
+fn inline_word_chunks(text: &str, code: bool, has_background: bool) -> Vec<&str> {
+    if text.is_empty() {
+        return Vec::new();
+    }
+    if code || has_background {
+        return vec![text];
+    }
+    text.split_inclusive(char::is_whitespace).collect()
+}
+
 #[cfg(test)]
 mod tests {
-    use super::{HtmlComputedStyle, column_axis_gutter_visible, html_node_visual_style};
+    use super::{
+        HtmlComputedStyle, column_axis_gutter_visible, html_node_visual_style, inline_word_chunks,
+    };
     use crate::components::{Block, BlockKind, BlockRecord, InlineTextTree, parse_html_document};
     use crate::components::{TableAxisKind, TableAxisMarker};
     use crate::i18n::I18nManager;
@@ -2917,6 +3092,32 @@ mod tests {
         assert!((channel(color.g) - green as i16).abs() <= 1);
         assert!((channel(color.b) - blue as i16).abs() <= 1);
         assert!((channel(color.a) - alpha as i16).abs() <= 1);
+    }
+
+    #[test]
+    fn inline_word_chunks_split_text_runs_for_wrapping() {
+        // Plain runs split per word so the flex-wrap row can break between
+        // words and keep neighboring inline math on the same visual line.
+        assert_eq!(
+            inline_word_chunks("Fusce x malesuada", false, false),
+            vec!["Fusce ", "x ", "malesuada"],
+        );
+        // Trailing whitespace stays attached so spacing survives the split.
+        assert_eq!(inline_word_chunks("end ", false, false), vec!["end "]);
+        assert!(inline_word_chunks("", false, false).is_empty());
+    }
+
+    #[test]
+    fn inline_word_chunks_keep_boxed_runs_whole() {
+        // Inline code and background highlights keep their box continuous.
+        assert_eq!(
+            inline_word_chunks("let x = 2", true, false),
+            vec!["let x = 2"],
+        );
+        assert_eq!(
+            inline_word_chunks("highlighted text", false, true),
+            vec!["highlighted text"],
+        );
     }
 
     #[test]

--- a/src/components/block/runtime/mod.rs
+++ b/src/components/block/runtime/mod.rs
@@ -145,7 +145,6 @@ pub struct Block {
     /// instead of re-allocating per frame. Refreshed in `sync_render_cache`,
     /// `rebuild_inline_projection`, and `clear_inline_projection`.
     cached_display_text: SharedString,
-    inline_math_source_edit_original: Option<InlineTextTree>,
     collapsed_caret_affinity: CollapsedCaretAffinity,
     /// When true, block-level shortcuts and inline formatting are
     /// suppressed; the block stores raw text for source-mode editing.
@@ -243,7 +242,6 @@ impl Block {
             projection: None,
             projection_cache_key: None,
             cached_display_text: SharedString::default(),
-            inline_math_source_edit_original: None,
             collapsed_caret_affinity: CollapsedCaretAffinity::Default,
             edit_mode,
             show_source_line_numbers: false,
@@ -419,90 +417,6 @@ impl Block {
         self.record.title.has_mixed_inline_visuals()
     }
 
-    pub(crate) fn inline_math_source_editing(&self) -> bool {
-        self.inline_math_source_edit_original.is_some()
-    }
-
-    pub(crate) fn split_inline_math_source_edit_for_newline(&mut self) -> Option<InlineTextTree> {
-        self.inline_math_source_edit_original.as_ref()?;
-
-        let raw_markdown = self.record.title.visible_text().to_string();
-        let len = raw_markdown.len();
-        let start = self.selected_range.start.min(len);
-        let end = self.selected_range.end.min(len);
-        let leading_raw = &raw_markdown[..start];
-        let trailing_raw = &raw_markdown[end..];
-        let leading = InlineTextTree::from_markdown_with_link_references(
-            leading_raw,
-            &self.link_reference_definitions,
-        );
-        let trailing = InlineTextTree::from_markdown_with_link_references(
-            trailing_raw,
-            &self.link_reference_definitions,
-        );
-
-        self.inline_math_source_edit_original = None;
-        self.record.set_title(leading);
-        self.edit_mode = EditMode::for_kind(&self.record.kind);
-        self.clear_inline_projection();
-        self.sync_render_cache();
-        let cursor = self.visible_len();
-        self.selected_range = cursor..cursor;
-        self.marked_range = None;
-        self.collapsed_caret_affinity = CollapsedCaretAffinity::Default;
-
-        Some(trailing)
-    }
-
-    pub(crate) fn sync_inline_math_source_edit_for_focus(&mut self, focused: bool) -> bool {
-        if focused
-            && self.inline_math_source_edit_original.is_none()
-            && self.edit_mode == EditMode::RenderedRich
-            && self.record.title.has_inline_math()
-        {
-            let clean_selection = self.selected_range.clone();
-            let clean_marked = self.marked_range.clone();
-            let markdown_map = self.record.title.markdown_offset_map();
-            let markdown_selection = markdown_map.visible_to_markdown_range(clean_selection);
-            let markdown_marked =
-                clean_marked.map(|range| markdown_map.visible_to_markdown_range(range));
-            let original = self.record.title.clone();
-            let raw_markdown = original.serialize_markdown();
-            self.inline_math_source_edit_original = Some(original);
-            self.clear_inline_projection();
-            self.record.title = InlineTextTree::plain(raw_markdown);
-            self.edit_mode = EditMode::SourceRaw;
-            self.sync_render_cache();
-            let len = self.visible_len();
-            self.selected_range =
-                markdown_selection.start.min(len)..markdown_selection.end.min(len);
-            self.marked_range =
-                markdown_marked.map(|range| range.start.min(len)..range.end.min(len));
-            self.collapsed_caret_affinity = CollapsedCaretAffinity::Default;
-            return true;
-        }
-
-        if !focused && let Some(_original) = self.inline_math_source_edit_original.take() {
-            let raw_markdown = self.record.title.visible_text().to_string();
-            let parsed = InlineTextTree::from_markdown_with_link_references(
-                &raw_markdown,
-                &self.link_reference_definitions,
-            );
-            let markdown_selection = self.selected_range.clone();
-            let markdown_marked = self.marked_range.clone();
-            let map = parsed.markdown_offset_map();
-            self.record.set_title(parsed);
-            self.edit_mode = EditMode::for_kind(&self.record.kind);
-            self.sync_render_cache();
-            self.selected_range = map.markdown_to_visible_range(markdown_selection);
-            self.marked_range = markdown_marked.map(|range| map.markdown_to_visible_range(range));
-            self.collapsed_caret_affinity = CollapsedCaretAffinity::Default;
-            return true;
-        }
-
-        false
-    }
-
     pub(crate) fn footnote_definition_id(&self) -> Option<String> {
         self.kind()
             .is_footnote_definition()
@@ -584,6 +498,7 @@ impl Block {
             .clone()
             .map(|range| self.current_to_clean_range(range));
         let (clean_anchor, clean_focus) = self.clean_selection_anchor_focus();
+        let (anchor_affinity, focus_affinity) = self.selection_endpoint_affinities();
         let collapsed_affinity = self.current_collapsed_caret_affinity();
         let keep_projection =
             self.projection.is_some() && self.edit_mode.supports_inline_projection();
@@ -601,7 +516,12 @@ impl Block {
                 );
                 self.assign_collapsed_selection_offset(offset, collapsed_affinity, None);
             } else {
-                self.set_selection_from_clean_anchor_focus(clean_anchor, clean_focus);
+                self.set_selection_from_clean_anchor_focus(
+                    clean_anchor,
+                    clean_focus,
+                    anchor_affinity,
+                    focus_affinity,
+                );
                 self.collapsed_caret_affinity = CollapsedCaretAffinity::Default;
             }
             self.marked_range = clean_marked.map(|range| self.clean_to_current_range(range));
@@ -754,6 +674,7 @@ impl Block {
         mark_inserted_text: bool,
         cx: &mut Context<Self>,
     ) {
+        let old_visible_len = self.record.title.visible_text().len();
         let markdown_range = self.current_range_to_markdown_range(visible_range.clone());
         let mut markdown = self.record.title.serialize_markdown();
         let replaced_text = markdown[markdown_range.clone()].to_string();
@@ -793,6 +714,14 @@ impl Block {
             self.quote_reparse_requested = true;
         }
 
+        // Typing a closing marker (for example the `)` that completes a link)
+        // absorbs that markup into a span, so the clean text grows by less than
+        // the inserted text. Flag it so the caret is placed just past the new
+        // closing delimiter instead of landing inside the span.
+        let caret_may_have_closed_span = !new_text.is_empty()
+            && !mark_inserted_text
+            && next_title.visible_text().len() < old_visible_len + new_text.len();
+
         self.apply_title_edit(
             next_title,
             cursor_clean,
@@ -801,7 +730,7 @@ impl Block {
             selected_clean
                 .as_ref()
                 .and_then(|range| (!range.is_empty()).then_some(false)),
-            false,
+            caret_may_have_closed_span,
             cx,
         );
     }
@@ -851,6 +780,7 @@ impl Block {
             return;
         }
         let (clean_anchor, clean_focus) = self.clean_selection_anchor_focus();
+        let (anchor_affinity, focus_affinity) = self.selection_endpoint_affinities();
         let collapsed_affinity = self.current_collapsed_caret_affinity();
         self.rebuild_inline_projection(clean_selected.clone(), clean_marked.clone());
         if let Some(snapshot) = projected_link_selection
@@ -879,7 +809,12 @@ impl Block {
             );
             self.assign_collapsed_selection_offset(offset, collapsed_affinity, None);
         } else {
-            self.set_selection_from_clean_anchor_focus(clean_anchor, clean_focus);
+            self.set_selection_from_clean_anchor_focus(
+                clean_anchor,
+                clean_focus,
+                anchor_affinity,
+                focus_affinity,
+            );
             self.collapsed_caret_affinity = CollapsedCaretAffinity::Default;
         }
         self.marked_range = clean_marked.map(|range| self.clean_to_current_range(range));
@@ -936,6 +871,23 @@ impl Block {
         self.projection
             .as_ref()
             .and_then(|projection| projection.link_run_fully_covering_range(range))
+    }
+
+    fn collapsed_caret_affinity_for_display_offset(&self, offset: usize) -> CollapsedCaretAffinity {
+        self.projection
+            .as_ref()
+            .map(|projection| projection.collapsed_affinity_for_display_offset(offset))
+            .unwrap_or(CollapsedCaretAffinity::Default)
+    }
+
+    /// Affinity of the current selection's anchor and focus, used to restore
+    /// each endpoint accurately when the projection is rebuilt.
+    fn selection_endpoint_affinities(&self) -> (CollapsedCaretAffinity, CollapsedCaretAffinity) {
+        let (anchor, focus) = self.selection_anchor_focus();
+        (
+            self.collapsed_caret_affinity_for_display_offset(anchor),
+            self.collapsed_caret_affinity_for_display_offset(focus),
+        )
     }
 
     fn current_collapsed_caret_affinity(&self) -> CollapsedCaretAffinity {
@@ -1685,6 +1637,29 @@ impl Block {
 
         let inserted_attributes = self.replacement_attributes_for_visible_range(&visible_range);
 
+        // Inline `[label](url)` links round-trip through their projected source,
+        // so edit them via the link projection even when the block is otherwise
+        // source-preserving (for example it also contains inline math). This keeps
+        // a link's anchor text editable the same way in every block; reference and
+        // autolink links stay on the markdown-space path below, which preserves
+        // their original source spelling.
+        if !self.uses_raw_text_editing()
+            && let Some(link_run) = self
+                .projected_link_run_fully_covering_range(&visible_range)
+                .filter(|run| !run.link.is_source_preserving())
+                .cloned()
+        {
+            self.apply_link_projection_edit(
+                &link_run,
+                visible_range,
+                new_text,
+                selected_range_relative,
+                mark_inserted_text,
+                cx,
+            );
+            return;
+        }
+
         if self.should_use_markdown_space_link_edit() {
             self.apply_markdown_space_title_edit(
                 visible_range,
@@ -1696,13 +1671,12 @@ impl Block {
             return;
         }
 
-        if !self.uses_raw_text_editing()
-            && let Some(link_run) = self
-                .projected_link_run_fully_covering_range(&visible_range)
-                .cloned()
-        {
-            self.apply_link_projection_edit(
-                &link_run,
+        // Editing outside an inline link's run would otherwise re-derive the
+        // inline tree from collapsed visible text, which no longer contains the
+        // `[label](url)` markers and silently drops the link. Edit in markdown
+        // space (as source-preserving links already do) so the link round-trips.
+        if !self.uses_raw_text_editing() && self.record.title.has_inline_links() {
+            self.apply_markdown_space_title_edit(
                 visible_range,
                 new_text,
                 selected_range_relative,
@@ -1839,23 +1813,21 @@ impl Block {
         cx.notify();
     }
 
-    pub(crate) fn enter_math_block(&mut self, cx: &mut Context<Self>) {
-        const EMPTY_DISPLAY_MATH_SOURCE: &str = "$$\n\n$$";
-        const EMPTY_DISPLAY_MATH_CURSOR: usize = "$$\n".len();
+    /// Convert the current paragraph into a display-math block. `body` becomes
+    /// the formula source between the fences (empty for a fresh `$$` block), and
+    /// the caret lands at the start of that body line.
+    pub(crate) fn enter_math_block(&mut self, body: &str, cx: &mut Context<Self>) {
+        let source = format!("$$\n{body}\n$$");
+        let cursor = "$$\n".len();
 
         self.prepare_undo_capture(UndoCaptureKind::NonCoalescible, cx);
         self.clear_inline_projection();
         self.record.kind = BlockKind::MathBlock;
-        self.record
-            .set_title(InlineTextTree::plain(EMPTY_DISPLAY_MATH_SOURCE));
+        self.record.set_title(InlineTextTree::plain(source));
         self.quote_reparse_requested = false;
         self.sync_edit_mode_from_kind();
         self.sync_render_cache();
-        self.assign_collapsed_selection_offset(
-            EMPTY_DISPLAY_MATH_CURSOR,
-            CollapsedCaretAffinity::Default,
-            None,
-        );
+        self.assign_collapsed_selection_offset(cursor, CollapsedCaretAffinity::Default, None);
         self.marked_range = None;
         self.cursor_blink_epoch = Instant::now();
         self.clear_vertical_motion();
@@ -2119,10 +2091,22 @@ impl Block {
         self.selection_reversed = !self.selected_range.is_empty() && clamped_focus < clamped_anchor;
     }
 
-    fn set_selection_from_clean_anchor_focus(&mut self, anchor: usize, focus: usize) {
+    fn set_selection_from_clean_anchor_focus(
+        &mut self,
+        anchor: usize,
+        focus: usize,
+        anchor_affinity: CollapsedCaretAffinity,
+        focus_affinity: CollapsedCaretAffinity,
+    ) {
+        // Map each endpoint back through its own affinity. Several display
+        // positions can share one clean offset (a trailing link's `](url)`
+        // delimiters all collapse onto the anchor-text end), so the plain
+        // clean->display cursor map would snap an endpoint that sat after the
+        // closing delimiter back to just inside it. Honoring the captured
+        // affinity keeps such endpoints in place across a projection rebuild.
         self.set_selection_from_anchor_focus(
-            self.clean_to_current_cursor_offset(anchor),
-            self.clean_to_current_cursor_offset(focus),
+            self.clean_to_current_cursor_offset_with_affinity(anchor, anchor_affinity),
+            self.clean_to_current_cursor_offset_with_affinity(focus, focus_affinity),
         );
     }
 

--- a/src/components/block/runtime/projection.rs
+++ b/src/components/block/runtime/projection.rs
@@ -451,26 +451,34 @@ impl ExpandedInlineProjection {
                     let current_fragment = &fragments[current_index];
                     let current_len = current_fragment.text.len();
                     let current_clean_range = local_clean_cursor..local_clean_cursor + current_len;
-                    projected_fragments.push(current_fragment.clone());
-                    segments.push(ExpandedInlineSegment {
-                        display_range: display_cursor..display_cursor + current_len,
-                        clean_range: current_clean_range.clone(),
-                        fragment_index: current_index,
+                    // While the link is expanded, reveal each label fragment's
+                    // own emphasis markers so anchor text edits like ordinary text.
+                    let label_kinds = if expand_link {
+                        Self::expanded_kinds_for_fragment(
+                            fragments,
+                            current_index,
+                            current_fragment.style,
+                            current_clean_range.clone(),
+                            &clean_selected,
+                            clean_marked.as_ref(),
+                        )
+                    } else {
+                        Vec::new()
+                    };
+                    push_projected_fragment(
+                        current_fragment,
+                        current_index,
+                        current_clean_range.clone(),
+                        &label_kinds,
                         link_group,
-                        kind: if expand_link {
-                            ExpandedInlineSegmentKind::StyledText
-                        } else {
-                            ExpandedInlineSegmentKind::PlainText
-                        },
-                    });
-                    for offset in 0..=current_len {
-                        clean_to_display_cursor[current_clean_range.start + offset] =
-                            display_cursor + offset;
-                    }
-                    for offset in 1..=current_len {
-                        display_to_clean.push(current_clean_range.start + offset);
-                    }
-                    display_cursor += current_len;
+                        expand_link,
+                        &mut projected_fragments,
+                        &mut segments,
+                        &mut clean_to_display_cursor,
+                        &mut display_to_clean,
+                        &mut display_cursor,
+                        &mut any_expanded,
+                    );
                     local_clean_cursor = current_clean_range.end;
                 }
                 if expand_link {
@@ -573,77 +581,20 @@ impl ExpandedInlineProjection {
                 clean_marked.as_ref(),
             );
 
-            for kind in &expanded_kinds {
-                any_expanded = true;
-                let marker = kind.open_marker().to_string();
-                let marker_len = marker.len();
-                let marker_style = marker_style_for_projection(fragment.style, *kind);
-                projected_fragments.push(InlineFragment {
-                    text: marker,
-                    style: marker_style,
-                    html_style: fragment.html_style,
-                    link: None,
-                    footnote: None,
-                    math: None,
-                });
-                segments.push(ExpandedInlineSegment {
-                    display_range: display_cursor..display_cursor + marker_len,
-                    clean_range: clean_range.start..clean_range.start,
-                    fragment_index,
-                    link_group: None,
-                    kind: ExpandedInlineSegmentKind::OpeningDelimiter(*kind),
-                });
-                for _ in 0..marker_len {
-                    display_to_clean.push(clean_range.start);
-                }
-                display_cursor += marker_len;
-            }
-
-            let text_segment_kind = if expanded_kinds.is_empty() {
-                ExpandedInlineSegmentKind::PlainText
-            } else {
-                ExpandedInlineSegmentKind::StyledText
-            };
-            projected_fragments.push(fragment.clone());
-            segments.push(ExpandedInlineSegment {
-                display_range: display_cursor..display_cursor + fragment_len,
-                clean_range: clean_range.clone(),
+            push_projected_fragment(
+                fragment,
                 fragment_index,
-                link_group: None,
-                kind: text_segment_kind,
-            });
-            for offset in 0..=fragment_len {
-                clean_to_display_cursor[clean_range.start + offset] = display_cursor + offset;
-            }
-            for offset in 1..=fragment_len {
-                display_to_clean.push(clean_range.start + offset);
-            }
-            display_cursor += fragment_len;
-
-            for kind in expanded_kinds.iter().rev() {
-                let marker = kind.close_marker().to_string();
-                let marker_len = marker.len();
-                let marker_style = marker_style_for_projection(fragment.style, *kind);
-                projected_fragments.push(InlineFragment {
-                    text: marker,
-                    style: marker_style,
-                    html_style: fragment.html_style,
-                    link: None,
-                    footnote: None,
-                    math: None,
-                });
-                segments.push(ExpandedInlineSegment {
-                    display_range: display_cursor..display_cursor + marker_len,
-                    clean_range: clean_range.end..clean_range.end,
-                    fragment_index,
-                    link_group: None,
-                    kind: ExpandedInlineSegmentKind::ClosingDelimiter(*kind),
-                });
-                for _ in 0..marker_len {
-                    display_to_clean.push(clean_range.end);
-                }
-                display_cursor += marker_len;
-            }
+                clean_range.clone(),
+                &expanded_kinds,
+                None,
+                false,
+                &mut projected_fragments,
+                &mut segments,
+                &mut clean_to_display_cursor,
+                &mut display_to_clean,
+                &mut display_cursor,
+                &mut any_expanded,
+            );
 
             clean_cursor = clean_range.end;
             fragment_index += 1;
@@ -995,4 +946,98 @@ fn marker_style_for_projection(mut style: InlineStyle, kind: ExpandedInlineKind)
         style.script = InlineScript::Normal;
     }
     style
+}
+
+/// Emit one inline fragment, wrapped in the projected emphasis delimiters for
+/// `kinds`. Shared by standalone and link-label fragments so anchor text reveals
+/// its bold/italic/code markers like ordinary text. `force_styled` keeps a
+/// marker-less fragment styled (link labels while a link run is expanded).
+#[allow(clippy::too_many_arguments)]
+fn push_projected_fragment(
+    fragment: &InlineFragment,
+    fragment_index: usize,
+    clean_range: Range<usize>,
+    kinds: &[ExpandedInlineKind],
+    link_group: Option<usize>,
+    force_styled: bool,
+    projected_fragments: &mut Vec<InlineFragment>,
+    segments: &mut Vec<ExpandedInlineSegment>,
+    clean_to_display_cursor: &mut [usize],
+    display_to_clean: &mut Vec<usize>,
+    display_cursor: &mut usize,
+    any_expanded: &mut bool,
+) {
+    let fragment_len = fragment.text.len();
+
+    for kind in kinds {
+        *any_expanded = true;
+        let marker = kind.open_marker().to_string();
+        let marker_len = marker.len();
+        let marker_style = marker_style_for_projection(fragment.style, *kind);
+        projected_fragments.push(InlineFragment {
+            text: marker,
+            style: marker_style,
+            html_style: fragment.html_style,
+            link: None,
+            footnote: None,
+            math: None,
+        });
+        segments.push(ExpandedInlineSegment {
+            display_range: *display_cursor..*display_cursor + marker_len,
+            clean_range: clean_range.start..clean_range.start,
+            fragment_index,
+            link_group,
+            kind: ExpandedInlineSegmentKind::OpeningDelimiter(*kind),
+        });
+        for _ in 0..marker_len {
+            display_to_clean.push(clean_range.start);
+        }
+        *display_cursor += marker_len;
+    }
+
+    let text_segment_kind = if kinds.is_empty() && !force_styled {
+        ExpandedInlineSegmentKind::PlainText
+    } else {
+        ExpandedInlineSegmentKind::StyledText
+    };
+    projected_fragments.push(fragment.clone());
+    segments.push(ExpandedInlineSegment {
+        display_range: *display_cursor..*display_cursor + fragment_len,
+        clean_range: clean_range.clone(),
+        fragment_index,
+        link_group,
+        kind: text_segment_kind,
+    });
+    for offset in 0..=fragment_len {
+        clean_to_display_cursor[clean_range.start + offset] = *display_cursor + offset;
+    }
+    for offset in 1..=fragment_len {
+        display_to_clean.push(clean_range.start + offset);
+    }
+    *display_cursor += fragment_len;
+
+    for kind in kinds.iter().rev() {
+        let marker = kind.close_marker().to_string();
+        let marker_len = marker.len();
+        let marker_style = marker_style_for_projection(fragment.style, *kind);
+        projected_fragments.push(InlineFragment {
+            text: marker,
+            style: marker_style,
+            html_style: fragment.html_style,
+            link: None,
+            footnote: None,
+            math: None,
+        });
+        segments.push(ExpandedInlineSegment {
+            display_range: *display_cursor..*display_cursor + marker_len,
+            clean_range: clean_range.end..clean_range.end,
+            fragment_index,
+            link_group,
+            kind: ExpandedInlineSegmentKind::ClosingDelimiter(*kind),
+        });
+        for _ in 0..marker_len {
+            display_to_clean.push(clean_range.end);
+        }
+        *display_cursor += marker_len;
+    }
 }

--- a/src/components/block/runtime/tests.rs
+++ b/src/components/block/runtime/tests.rs
@@ -10,7 +10,9 @@ use crate::components::markdown::inline::{
     InlineTextTree,
 };
 use crate::components::markdown::link::parse_link_reference_definitions;
-use crate::components::{Block, BlockKind, BlockRecord, IndentBlock, Newline, TableCellPosition};
+use crate::components::{
+    Block, BlockKind, BlockRecord, DeleteBack, IndentBlock, Newline, TableCellPosition,
+};
 use crate::i18n::I18nManager;
 use crate::theme::ThemeManager;
 use gpui::{
@@ -188,27 +190,40 @@ async fn enter_inside_multiline_inline_code_inserts_hard_line_without_splitting(
 }
 
 #[gpui::test]
-async fn inline_math_focus_uses_markdown_source_then_reparses_on_blur(cx: &mut TestAppContext) {
+async fn inline_math_focus_stays_rendered_rich_and_keeps_links(cx: &mut TestAppContext) {
     let cx = cx.add_empty_window();
     let block = cx.new(|cx| {
         Block::with_record(
             cx,
             BlockRecord::new(
                 BlockKind::Paragraph,
-                InlineTextTree::from_markdown("**bold** $x^2$"),
+                InlineTextTree::from_markdown("**bold** $x^2$ [repo](https://example.com)"),
             ),
         )
     });
 
-    block.update(cx, |block, _cx| {
-        assert_eq!(block.display_text(), "bold $x^2$");
-        assert!(block.sync_inline_math_source_edit_for_focus(true));
-        assert!(block.uses_raw_text_editing());
-        assert_eq!(block.display_text(), "**bold** $x^2$");
-        assert!(block.sync_inline_math_source_edit_for_focus(false));
+    block.update(cx, |block, cx| {
+        // The math source is shown inline (`$x^2$`) while bold and the link stay
+        // collapsed; the block never falls back to raw Markdown editing.
+        assert_eq!(block.display_text(), "bold $x^2$ repo");
+
+        // Focusing with the caret inside the math keeps the rendered-rich
+        // projection rather than dumping the whole block to raw source, so the
+        // link in the same block keeps its link attribute.
+        let caret = "bold $".len();
+        block.move_to(caret, cx);
+        block.sync_inline_projection_for_focus(true);
         assert!(!block.uses_raw_text_editing());
-        assert_eq!(block.display_text(), "bold $x^2$");
-        assert_eq!(block.record.title.serialize_markdown(), "**bold** $x^2$");
+        assert!(block.record.title.has_mixed_inline_visuals());
+        assert!(block.record.title.has_inline_links());
+        assert!(
+            block.inline_spans().iter().any(|span| span.link.is_some()),
+            "link must stay styled while editing the math in the same block"
+        );
+        assert_eq!(
+            block.record.title.serialize_markdown(),
+            "**bold** $x^2$ [repo](https://example.com)"
+        );
     });
 }
 
@@ -232,10 +247,35 @@ async fn script_spans_focus_stay_rendered_rich(cx: &mut TestAppContext) {
             block.inline_spans()[1].style.script,
             InlineScript::Superscript
         );
-        assert!(!block.sync_inline_math_source_edit_for_focus(true));
         assert!(!block.uses_raw_text_editing());
         assert_eq!(block.display_text(), "x2 and H2O");
         assert_eq!(block.record.title.serialize_markdown(), "x^2^ and H~2~O");
+    });
+}
+
+#[gpui::test]
+async fn link_anchor_emphasis_delimiters_are_revealed_when_caret_inside(cx: &mut TestAppContext) {
+    let cx = cx.add_empty_window();
+    let block = cx.new(|cx| {
+        Block::with_record(
+            cx,
+            BlockRecord::new(
+                BlockKind::Paragraph,
+                InlineTextTree::from_markdown("[**bold**](https://example.com)"),
+            ),
+        )
+    });
+
+    block.update(cx, |block, cx| {
+        // Collapsed, only the styled anchor text is shown.
+        assert_eq!(block.display_text(), "bold");
+
+        // With the caret inside the bold anchor text, the projection reveals both
+        // the link syntax and the anchor's own `**` emphasis markers, so they can
+        // be edited instead of staying invisible.
+        block.move_to(2, cx);
+        block.sync_inline_projection_for_focus(true);
+        assert_eq!(block.display_text(), "[**bold**](https://example.com)");
     });
 }
 
@@ -1576,6 +1616,40 @@ async fn editing_link_destination_inside_projection_preserves_link(cx: &mut Test
 }
 
 #[gpui::test]
+async fn typing_after_inline_link_preserves_link(cx: &mut TestAppContext) {
+    let block = cx.new(|cx| {
+        Block::with_record(
+            cx,
+            BlockRecord::new(
+                BlockKind::Paragraph,
+                InlineTextTree::from_markdown("[Link](https://example.com/) x"),
+            ),
+        )
+    });
+
+    block.update(cx, |block, cx| {
+        // Place the caret past the link (in the trailing text) so the edit does
+        // not touch the link's projected run, then type. This is the case that
+        // previously re-parsed from collapsed text and dropped the link.
+        block.selected_range = 0..0;
+        block.sync_inline_projection_for_focus(true);
+        let end = block.display_text().len();
+        block.selected_range = end..end;
+        block.sync_inline_projection_for_focus(true);
+        block.replace_text_in_visible_range(end..end, "y", None, false, cx);
+    });
+
+    assert_eq!(
+        block.read_with(cx, |block, _cx| block.record.title.serialize_markdown()),
+        "[Link](https://example.com/) xy"
+    );
+    assert_eq!(
+        block.read_with(cx, |block, _cx| block.inline_link_at(0).map(str::to_string)),
+        Some("https://example.com/".to_string())
+    );
+}
+
+#[gpui::test]
 async fn deleting_adjacent_text_preserves_reference_style_link_syntax(cx: &mut TestAppContext) {
     let block = cx.new(|cx| {
         let mut block = Block::with_record(
@@ -2743,4 +2817,125 @@ async fn code_block_without_language_keeps_plain_rendering(cx: &mut TestAppConte
     });
 
     assert!(block.read_with(cx, |block, _cx| block.code_highlight_result().is_none()));
+}
+
+#[gpui::test]
+async fn editing_link_anchor_in_math_block_matches_plain_paragraph(cx: &mut TestAppContext) {
+    // A block mixing inline math with a link is "source preserving", which used
+    // to route its link edits through the markdown-space path. That path assumed
+    // the anchor label began right after `[`, so the anchor's own emphasis
+    // markers shifted the mapping and edits landed on the wrong character. Inline
+    // links now edit through the link projection in every block, so deleting a
+    // revealed anchor delimiter touches the delimiter, not a label character.
+    let cx = cx.add_empty_window();
+    let block = cx.new(|cx| {
+        Block::with_record(
+            cx,
+            BlockRecord::new(
+                BlockKind::Paragraph,
+                InlineTextTree::from_markdown("$x^2$ [**bold**](https://e.com)"),
+            ),
+        )
+    });
+
+    cx.update(|window, cx| {
+        block.update(cx, |block, cx| {
+            block.move_to("$x^2$ bo".len(), cx);
+            block.sync_inline_projection_for_focus(true);
+
+            // Caret just past the revealed opening `**` of the bold anchor.
+            let projected = block.display_text().to_string();
+            assert_eq!(projected, "$x^2$ [**bold**](https://e.com)");
+            let after_open = projected.find("[**").unwrap() + "[**".len();
+            block.selected_range = after_open..after_open;
+
+            block.on_delete_back(&DeleteBack, window, cx);
+
+            let markdown = block.record.title.serialize_markdown();
+            assert!(
+                markdown.starts_with("$x^2$ "),
+                "math source preserved: {markdown:?}"
+            );
+            assert!(
+                markdown.contains("bold"),
+                "anchor label must stay intact, only the delimiter is edited: {markdown:?}"
+            );
+        });
+    });
+}
+
+#[gpui::test]
+async fn completing_link_in_math_block_places_caret_after_closing_paren(cx: &mut TestAppContext) {
+    // A block mixing math with a link edits in markdown space. Typing the closing
+    // `)` completes the link, and the caret must land just past it (like a plain
+    // paragraph) rather than inside the anchor before `]`.
+    let cx = cx.add_empty_window();
+    let block = cx.new(|cx| {
+        Block::with_record(
+            cx,
+            BlockRecord::new(
+                BlockKind::Paragraph,
+                InlineTextTree::from_markdown("$x$ [link](google.com"),
+            ),
+        )
+    });
+
+    cx.update(|window, cx| {
+        block.update(cx, |block, cx| {
+            block.move_to(block.visible_len(), cx);
+            block.sync_inline_projection_for_focus(true);
+            block.replace_text_in_range(None, ")", window, cx);
+            block.sync_inline_projection_for_focus(true);
+
+            assert_eq!(
+                block.record.title.serialize_markdown(),
+                "$x$ [link](google.com)"
+            );
+            assert_eq!(block.display_text(), "$x$ [link](google.com)");
+            let end = block.visible_len();
+            assert_eq!(block.selected_range, end..end);
+        });
+    });
+}
+
+#[gpui::test]
+async fn rtl_selection_across_trailing_link_keeps_block_end_anchor(cx: &mut TestAppContext) {
+    // A link sitting at the very end of a block that also contains inline math
+    // stays expanded while the projection is rebuilt on every render. Dragging a
+    // selection right-to-left from the block end across the link used to collapse
+    // the anchor onto the closing `]` of the anchor text, because the trailing
+    // `](url)` delimiters all share one clean offset and the remap snapped back
+    // to the inner cursor position. The anchor must stay at the block end.
+    let cx = cx.add_empty_window();
+    let block = cx.new(|cx| {
+        Block::with_record(
+            cx,
+            BlockRecord::new(
+                BlockKind::Paragraph,
+                InlineTextTree::from_markdown("$x$ [link](google.com)"),
+            ),
+        )
+    });
+
+    block.update(cx, |block, cx| {
+        block.move_to(block.visible_len(), cx);
+        block.sync_inline_projection_for_focus(true);
+        let end = block.visible_len();
+        assert_eq!(block.display_text(), "$x$ [link](google.com)");
+
+        // Start an RTL selection at the block end and drag the head left,
+        // re-syncing the projection after each move like the render loop does.
+        block.move_to(end, cx);
+        block.sync_inline_projection_for_focus(true);
+        for target in (0..end).rev() {
+            block.select_to(target, cx);
+            block.sync_inline_projection_for_focus(true);
+            assert_eq!(
+                block.selected_range,
+                target..end,
+                "RTL selection anchor must stay at the block end (head {target})"
+            );
+            assert!(block.selection_reversed);
+        }
+    });
 }

--- a/src/components/markdown/inline.rs
+++ b/src/components/markdown/inline.rs
@@ -522,10 +522,14 @@ impl InlineTextTree {
         })
     }
 
-    pub(crate) fn has_inline_math(&self) -> bool {
+    /// Whether any fragment carries an inline `[label](url)` link. Unlike
+    /// reference/autolink links these are not "source preserving", but their
+    /// `[...](...)` markers are still stripped from the fragment text, so an
+    /// edit that re-derives the tree from visible text alone would drop them.
+    pub(crate) fn has_inline_links(&self) -> bool {
         self.fragments
             .iter()
-            .any(|fragment| fragment.math.is_some())
+            .any(|fragment| matches!(fragment.link, Some(InlineLink::Inline { .. })))
     }
 
     pub(crate) fn has_mixed_inline_visuals(&self) -> bool {

--- a/src/editor/events.rs
+++ b/src/editor/events.rs
@@ -2014,7 +2014,6 @@ mod tests {
             editor.update(cx, |editor, cx| {
                 let block = editor.document.visible_blocks()[0].entity.clone();
                 block.update(cx, |block, block_cx| {
-                    assert!(!block.sync_inline_math_source_edit_for_focus(true));
                     block.move_to(block.visible_len(), block_cx);
                     block.on_newline(&Newline, window, block_cx);
                 });
@@ -2032,7 +2031,7 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn enter_inside_inline_math_source_edit_creates_new_block(cx: &mut TestAppContext) {
+    async fn enter_inside_inline_math_paragraph_creates_new_block(cx: &mut TestAppContext) {
         let cx = cx.add_empty_window();
         let editor = cx.new(|cx| Editor::from_markdown(cx, "$n^2$".to_string(), None));
 
@@ -2040,7 +2039,6 @@ mod tests {
             editor.update(cx, |editor, cx| {
                 let block = editor.document.visible_blocks()[0].entity.clone();
                 block.update(cx, |block, block_cx| {
-                    assert!(block.sync_inline_math_source_edit_for_focus(true));
                     block.move_to(block.visible_len(), block_cx);
                     block.on_newline(&Newline, window, block_cx);
                 });
@@ -2153,6 +2151,36 @@ mod tests {
             assert_eq!(block.selected_range, 3..3);
             assert!(block.uses_raw_text_editing());
             assert_eq!(editor.document.markdown_text(cx), "$$\n\n$$");
+        });
+    }
+
+    #[gpui::test]
+    async fn dollar_dollar_prefix_then_enter_wraps_existing_line(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let editor = cx.new(|cx| Editor::from_markdown(cx, "E = mc^2".to_string(), None));
+
+        cx.update(|window, cx| {
+            editor.update(cx, |editor, cx| {
+                let block = editor.document.visible_blocks()[0].entity.clone();
+                block.update(cx, |block, block_cx| {
+                    // Home, type the fence in front of the formula, then Enter.
+                    block.move_to(0, block_cx);
+                    block.replace_text_in_visible_range(0..0, "$$", None, false, block_cx);
+                    block.move_to("$$".len(), block_cx);
+                    block.on_newline(&Newline, window, block_cx);
+                });
+            });
+        });
+
+        editor.update(cx, |editor, cx| {
+            let visible = editor.document.visible_blocks();
+            assert_eq!(visible.len(), 1);
+            let block = visible[0].entity.read(cx);
+            assert_eq!(block.kind(), BlockKind::MathBlock);
+            // The pre-existing text is kept as the formula body.
+            assert_eq!(block.display_text(), "$$\nE = mc^2\n$$");
+            assert_eq!(block.selected_range, "$$\n".len().."$$\n".len());
+            assert_eq!(editor.document.markdown_text(cx), "$$\nE = mc^2\n$$");
         });
     }
 

--- a/src/editor/render.rs
+++ b/src/editor/render.rs
@@ -1901,12 +1901,25 @@ impl Render for Editor {
             .on_click(cx.listener(Self::on_toggle_view_mode));
         let content_area = content_area.child(view_mode_toggle);
 
+        // Repaint when the Cmd/Ctrl follow modifier toggles so a hovered link's
+        // hand cursor updates without moving the pointer. `ModifiersChanged` is
+        // dispatched along the focused element's path to the root, and this root
+        // is an ancestor of every block, so one listener here covers a link in any
+        // block while editing. Gated to the secondary modifier so Shift during
+        // selection does not repaint.
+        let follow_modifier_active = window.modifiers().secondary();
+
         let base = div()
             .w_full()
             .h_full()
             .relative()
             .bg(theme.colors.editor_background)
             .font(editor_text_font())
+            .on_modifiers_changed(move |event, window, _| {
+                if event.modifiers.secondary() != follow_modifier_active {
+                    window.refresh();
+                }
+            })
             .capture_action(cx.listener(Self::on_copy_capture))
             .capture_action(cx.listener(Self::on_cut_capture))
             .capture_action(cx.listener(Self::on_delete_capture))


### PR DESCRIPTION
This PR includes fixes for #75, #76, #77, as well as other fixes and improvements for links and inline math.

All changes are confined to the existing parser/runtime model. No new dependencies.

Unit tests have been added for all of the following.

## TL;DR

Inline math no longer forces an inappropriate line break inside a multi-line block/paragraph (#75).
Inline links inside blocks that also contain math, scripts, or inline images now remain functional (#76).
Inline links are no longer silently removed when you type elsewhere in the same block (#77).

Follow-up work, additional fixes/improvements along the way (sections 4-7):
- You can now Ctrl/Cmd+Left-Click on a link to follow/execute it. A plain click edits the text, and double-click still opens like it did before. The hand cursor over a link only appears while that modifier is held.
- Math blocks stay fully rendered while editing so their links and styling survive
- Anchor-text and link editing inside math blocks behave like a plain paragraph
- `$$`+Enter can now wrap an existing line into a display-math block
- Fixed a very strange right-to-left selection highlight bug in blocks with inline math that truncated around a trailing link.

## Full Rundown

### 1. Inline math no longer forces a line break (#75)

Issue: Blocks that mix inline visuals (math, subscript/superscript) render their inline content in a `flex_wrap` row where each styled text run is one flex item. A long run wraps internally, which makes its bounding box span the full row width and pushes the following item (the math) onto its own line.

Fix: Split plain text runs into one element per whitespace-delimited word so the row can break between words and keep the math on the same visual line. Inline code and background-highlighted runs stay a single element so their pill/background remains continuous.

### 2. Inline links stay functional in mixed inline-visual blocks (#76)

Issue: When a block also contains math or a script, its inline content renders as plain divs instead of the text element that normally handles link hit-testing, so links there could not be followed.

Fix: Attach open-link handlers directly to the rendered link runs in that path. See section 5 below for important details regarding this fix. This is an unusual capability for a Markdown editor, worth noting.

### 3. Inline links no longer vanish when typing past it in the same block (#77)

Issue: In Rendered mode, typing in the same block after an inline link (past its closing parenthesis) dropped the link. The fallback edit path re-derives the inline tree from the collapsed text, which no longer holds the `[label](url)` markers, so the link was lost.

Fix: Route edits in blocks that contain an inline link through the existing edit path, which serializes to markdown (with the markers), applies the edit, and re-parses. Reference and autolink links already use this path. This covers both web URLs and local-path links.

### 4. Link following uses Cmd/Ctrl+click

You can now Ctrl/Cmd+Left-Click on a link to follow/execute it. A plain click edits the text, and double-click still opens like it did before. This is inherent to the cursor interaction rather than a configurable shortcut, and it applies uniformly to every rendered link.

I considered left-click follow/execute, but decided this was too prone to misclicks, and Velotype seems editor-first rather than browser-like. The Ctrl/Cmd modifier follows the convention seen in some other text editors such as Word.

The hand cursor over a link now appears only while the modifier is held, matching the gesture. Toggling that cursor without moving the pointer requires a repaint when the modifier changes.

To feel as intuitive as possible, the hand cursor should appear and disappear the moment Cmd/Ctrl is pressed or released. It does so now in this PR's code, but with a minor caveat for Windows users: GPUI is currently unable to do this when a mouse cursor is stationary, it is a known bug. So on Windows, while the cursor is resting on a link, with no movement, and the user presses the modifier (Ctrl), the hand will not appear. On Windows, GPUI does not re-evaluate the cursor on a modifier change while the pointer is stationary, so the cursor will not update to or from the hand until the mouse is moved.

I don't like shipping with bugs but this is such a minor one, and doesn't affect Mac or Linux users, that I think it's worth keeping the modifier functionality. This is not a Velotype bug; it's a GPUI issue (with Windows). The problem had already been recognized on their end, and I plan to submit it as an Issue on their GitHub.

### 5. Math blocks stay rendered while editing, keeping links and styling

Focusing a block that contains inline math used to drop the whole block into raw Markdown source, which stripped the styling and link attributes from everything else in it. The block now stays in the projected rendered view (math shows as its editable `$...$` source) the same way script spans and ordinary text already behave, so links, bold, and other inline styling in the same block keep working while you edit the math. This makes the fix for #76 hold for editing as well as following. Editing them through the link projection (which already round-trips a link's projected source) reuses an existing path and fixes the offset mapping at the source.

### 6. Anchor-text and link editing inside math blocks now functions the same as in plain text blocks

- Delimiter/emphasis markers (bold, italic, code) inside a link's anchor text are now revealed in the projection when the caret is in the label, so already-applied markers can be edited instead of staying invisible.
- A block mixing inline math with a link is "source preserving," which routed its link edits through the markdown-space path. That path assumed the anchor text began immediately after `[`, so the anchor's own emphasis markers shifted the offset mapping and edits (including deleting a revealed delimiter) landed on the wrong character. Inline `[label](url)` links now edit through the link projection in every block, since they round-trip through their projected source.
- Typing the closing `)` of a link in a markdown-space block left the caret inside the anchor, before `]`. The caret now properly lands just after the `)` (the markdown-space path now computes the same "caret may have closed a span" signal the default path already used).

### 7. Right-to-left selection no longer truncates around a trailing link

I also found another minor very weirdly specific bug that became noticeable after fixing the links in blocks with inline math...if your link was at the precise tail end of that block, highlighting from right to left (across the link to the anchor text and beyond) truncated the highlighted portion to just inside the closing bracket of the anchor text as you continued highlighting to the left. Highlighting from the left-to-right worked fine. Another weird wrinkle was if you had any text to the right of the link, including an empty space, highlighting from any direction worked fine and the bug was not present.

Basically, right-to-left selection on trailing links was snapping incorrectly due to layout recalculations dropping the selection's affinity.

Fix: Carry each selection endpoint's caret affinity through the projection rebuild, so an endpoint sitting after a trailing closing delimiter is restored to its outer offset instead of the inner cursor position, the same way the collapsed caret already resolves that ambiguity, applying it to range endpoints.

## Ineffective solutions that were scrapped

Math wrapping (#75): marking each run `whitespace_nowrap`...long runs would overflow instead of wrapping.

Links in mixed blocks (#76): reusing the text element's hit-testing...would render discrete divs and never produce the wrapped-line the hit-test relies on.

Inline-link editing (#77): making them fully "source preserving"...would bypass and dead-code the dedicated in-link projection edit path, risking regressions when editing a link's label or destination.