### PR TITLE
Fix empty links

### DIFF
--- a/src/components/block/runtime/tests.rs
+++ b/src/components/block/runtime/tests.rs
@@ -2939,3 +2939,48 @@ async fn rtl_selection_across_trailing_link_keeps_block_end_anchor(cx: &mut Test
         }
     });
 }
+
+#[gpui::test]
+async fn typing_destination_into_empty_link_parens_keeps_caret_inside(cx: &mut TestAppContext) {
+    // Fixes an edge case where batched auto-pair macro `()+Left` caused first character typed
+    // into `()` of link to snap the caret past `)` with rest of URL landing outside the link.
+    let block = cx.new(|cx| {
+        Block::with_record(
+            cx,
+            BlockRecord::new(
+                BlockKind::Paragraph,
+                InlineTextTree::from_markdown("[GitHub]"),
+            ),
+        )
+    });
+
+    block.update(cx, |block, cx| {
+        // Auto-pair the `()` after the label, then drop the caret between them.
+        block.selected_range = 8..8;
+        block.sync_inline_projection_for_focus(true);
+        block.replace_text_in_visible_range(8..8, "()", None, false, cx);
+        block.sync_inline_projection_for_focus(true);
+        let between = block.display_text().find(')').expect("closing paren");
+        block.selected_range = between..between;
+        block.sync_inline_projection_for_focus(true);
+        for ch in "https://github.com".chars() {
+            let at = block.selected_range.clone();
+            block.replace_text_in_visible_range(at, &ch.to_string(), None, false, cx);
+            block.sync_inline_projection_for_focus(true);
+        }
+    });
+
+    block.read_with(cx, |block, _cx| {
+        assert_eq!(
+            block.record.title.serialize_markdown(),
+            "[GitHub](https://github.com)"
+        );
+        assert_eq!(
+            block.inline_link_at(1).map(str::to_string),
+            Some("https://github.com".to_string())
+        );
+        // Caret stays inside `()`, just before the closing `)`.
+        let close = block.display_text().find(')').expect("closing paren");
+        assert_eq!(block.selected_range, close..close);
+    });
+}

--- a/src/components/markdown/inline.rs
+++ b/src/components/markdown/inline.rs
@@ -2137,8 +2137,14 @@ fn locate_inline_link(
                 cursor += 1;
             };
 
-            let (destination, title) =
-                parse_link_target(&tokens_to_string(&tokens[url_start..url_end]))?;
+            // An empty destination such as in `[label]()` is a valid link, but the
+            // target parser rejects an empty string. Recognizing it keeps the caret
+            // inside the projected link while the destination is filled in.
+            let (destination, title) = if url_start == url_end {
+                (String::new(), None)
+            } else {
+                parse_link_target(&tokens_to_string(&tokens[url_start..url_end]))?
+            };
             Some(LocatedInlineLink {
                 label_end,
                 end_index: url_end,


### PR DESCRIPTION
With an empty `[label]()`, typing the first character of the destination dropped the caret just past the closing `)`, so the rest of the destination was typed outside the link. The first keystroke turned the run from plain text into a link, and that transition placed the caret after the new closing delimiter. This isn't caught by normally typing in char-by-char, so the edge case here was missed earlier in the fix for #77. This fix is very relevant for users who use auto-pair parentheses macros.

**Cause:** Empty destinations such as in `[label]()` were not recognized as links, because the target parser rejects an empty string.

**Fix:** Recognize an empty () as an inline link with an empty destination; this is fairly conventional. Now the caret stays inside the projected link while the destination is filled in.