### PR TITLE
Improve structural Markdown: setext/table typing, pipeless tables, paste, and table fixes

### DIFF
--- a/src/components/block/interactions.rs
+++ b/src/components/block/interactions.rs
@@ -311,6 +311,10 @@ impl Block {
             && self.selected_range.is_empty()
             && self.cursor_offset() == self.visible_len()
             && BlockKind::parse_separator_line(self.display_text())
+            // A dash run is also a setext underline; defer it to the editor so a
+            // preceding paragraph can become a heading (the editor falls back to
+            // a separator when there is no heading target).
+            && BlockKind::parse_setext_underline(self.display_text()).is_none()
         {
             self.convert_to_separator(cx);
             cx.emit(BlockEvent::RequestNewline {

--- a/src/components/block/render.rs
+++ b/src/components/block/render.rs
@@ -2535,7 +2535,7 @@ impl Render for Block {
                                                 });
                                             },
                                         )
-                                        .occlude(),
+                                        .block_mouse_except_scroll(),
                                 )
                         }),
                     )
@@ -2606,7 +2606,7 @@ impl Render for Block {
                                     });
                                 });
                             })
-                            .occlude(),
+                            .block_mouse_except_scroll(),
                     )
                     .children(header_cells.into_iter().enumerate().map(|(column, cell)| {
                         let hover_block = weak_table_block.clone();
@@ -2662,7 +2662,7 @@ impl Render for Block {
                                             });
                                         });
                                     })
-                                    .occlude(),
+                                    .block_mouse_except_scroll(),
                             )
                             .child(cell)
                     }));
@@ -2746,7 +2746,7 @@ impl Render for Block {
                                                 });
                                             },
                                         )
-                                        .occlude(),
+                                        .block_mouse_except_scroll(),
                                 )
                                 .children(row.into_iter().enumerate().map(|(column, cell)| {
                                     div()
@@ -2822,7 +2822,7 @@ impl Render for Block {
                                     .cursor_pointer()
                                     .text_size(px(t.text_size))
                                     .text_color(c.table_append_button_text)
-                                    .occlude()
+                                    .block_mouse_except_scroll()
                                     .on_hover(
                                         cx.listener(Self::on_table_append_column_button_hover),
                                     )
@@ -2867,7 +2867,7 @@ impl Render for Block {
                                     .cursor_pointer()
                                     .text_size(px(t.text_size))
                                     .text_color(c.table_append_button_text)
-                                    .occlude()
+                                    .block_mouse_except_scroll()
                                     .on_hover(cx.listener(Self::on_table_append_row_button_hover))
                                     .on_click(cx.listener(Self::on_append_table_row))
                                     .child("+"),

--- a/src/components/block/runtime/image.rs
+++ b/src/components/block/runtime/image.rs
@@ -18,6 +18,14 @@ impl Block {
             )
     }
 
+    /// Whether this block's text is a lone image that renders as a
+    /// self-contained image widget. Unlike `showing_rendered_image`, this is
+    /// derived from the title text rather than the computed runtime, so it is
+    /// valid before image runtimes are (re)built.
+    pub(crate) fn renders_as_standalone_image(&self) -> bool {
+        self.can_present_as_image() && self.standalone_image_markdown_for_runtime().is_some()
+    }
+
     pub(super) fn compute_image_runtime(
         &self,
         base_dir: Option<&Path>,

--- a/src/components/block/runtime/mod.rs
+++ b/src/components/block/runtime/mod.rs
@@ -1777,6 +1777,15 @@ impl Block {
 
     pub(crate) fn convert_to_separator(&mut self, cx: &mut Context<Self>) {
         self.prepare_undo_capture(UndoCaptureKind::NonCoalescible, cx);
+        self.make_separator();
+        cx.emit(BlockEvent::Changed);
+        cx.notify();
+    }
+
+    /// Turns this block into a separator in place without emitting events or
+    /// capturing undo, so editor-level flows that already manage those can
+    /// reuse the conversion.
+    pub(crate) fn make_separator(&mut self) {
         self.clear_inline_projection();
         self.record.kind = BlockKind::Separator;
         self.record.raw_fallback = None;
@@ -1788,8 +1797,6 @@ impl Block {
         self.marked_range = None;
         self.cursor_blink_epoch = Instant::now();
         self.clear_vertical_motion();
-        cx.emit(BlockEvent::Changed);
-        cx.notify();
     }
 
     pub(crate) fn enter_code_block(

--- a/src/components/block/runtime/table.rs
+++ b/src/components/block/runtime/table.rs
@@ -18,9 +18,9 @@ impl Block {
     pub(crate) fn text_align(&self) -> TextAlign {
         match self
             .table_cell_alignment()
-            .unwrap_or(TableColumnAlignment::Left)
+            .unwrap_or(TableColumnAlignment::Default)
         {
-            TableColumnAlignment::Left => TextAlign::Left,
+            TableColumnAlignment::Default | TableColumnAlignment::Left => TextAlign::Left,
             TableColumnAlignment::Center => TextAlign::Center,
             TableColumnAlignment::Right => TextAlign::Right,
         }

--- a/src/components/block/state.rs
+++ b/src/components/block/state.rs
@@ -198,6 +198,24 @@ impl BlockKind {
         matches!(self, Self::Quote | Self::Callout(_))
     }
 
+    /// Blocks that render as self-contained widgets with no caret position
+    /// after them. At the end of a rendered document they need a trailing
+    /// paragraph so a rendered-first user can keep typing past the structure
+    /// instead of having to drop to source mode.
+    pub fn is_atomic_structural(&self) -> bool {
+        matches!(
+            self,
+            Self::Separator
+                | Self::Table
+                | Self::CodeBlock { .. }
+                | Self::MathBlock
+                | Self::MermaidBlock
+                | Self::HtmlBlock
+                | Self::Comment
+                | Self::RawMarkdown
+        )
+    }
+
     pub fn is_callout(&self) -> bool {
         matches!(self, Self::Callout(_))
     }

--- a/src/components/markdown/paste.rs
+++ b/src/components/markdown/paste.rs
@@ -6,8 +6,16 @@
 //! the document block builder.
 
 use super::html::is_inline_tag;
+use super::table::collect_pipeless_table_region;
 
 pub(crate) fn should_split_plain_multiline_paste(lines: &[String]) -> bool {
+    // A pipeless GFM table reads cell-by-cell as plain lines, so detect the
+    // header-plus-delimiter shape explicitly and leave the whole paste to the
+    // block builder instead of splitting it into one paragraph per row.
+    if (0..lines.len()).any(|start| collect_pipeless_table_region(lines, start).is_some()) {
+        return false;
+    }
+
     lines.iter().filter(|line| !line.trim().is_empty()).count() >= 2
         && lines
             .iter()
@@ -35,7 +43,18 @@ fn is_plain_inline_paste_line(line: &str) -> bool {
         || is_simple_list_marker(trimmed)
         || is_simple_atx_heading(trimmed)
         || is_simple_separator(trimmed)
+        || is_setext_underline(trimmed)
         || is_simple_reference_definition(trimmed))
+}
+
+/// Matches a setext underline run (`=====` or `-----`). The `-` form is already
+/// covered by `is_simple_separator`, but `=` is not a thematic break, so without
+/// this a `text` + `=====` pair would be split into two plain paragraphs instead
+/// of routed to the structural importer as an H1.
+fn is_setext_underline(trimmed: &str) -> bool {
+    let core = trimmed.trim_end();
+    core.len() >= 3
+        && (core.bytes().all(|byte| byte == b'=') || core.bytes().all(|byte| byte == b'-'))
 }
 
 fn is_closed_inline_html_line(trimmed: &str) -> bool {
@@ -181,5 +200,37 @@ mod tests {
 
         let lines = vec!["# Title".to_string(), "body".to_string()];
         assert!(!should_split_plain_multiline_paste(&lines));
+    }
+
+    #[test]
+    fn rejects_setext_underline_pairs() {
+        // "=" underline must route to the structural importer (-> H1), like the
+        // "-" underline (-> H2) already did, rather than splitting into two
+        // plain paragraphs.
+        let lines = vec!["Title".to_string(), "=====".to_string()];
+        assert!(!should_split_plain_multiline_paste(&lines));
+
+        let lines = vec!["Title".to_string(), "-----".to_string()];
+        assert!(!should_split_plain_multiline_paste(&lines));
+    }
+
+    #[test]
+    fn rejects_pipeless_table() {
+        // A pipeless GFM table has no leading `|`, so its rows look like plain
+        // lines; the header-plus-delimiter shape must still route to the block
+        // builder instead of becoming one paragraph per row.
+        let lines = vec![
+            "Header 1 | Header 2 | Header 3".to_string(),
+            "-------- | -------- | --------".to_string(),
+            "Cell 1   | Cell 2   | Cell 3".to_string(),
+        ];
+        assert!(!should_split_plain_multiline_paste(&lines));
+
+        // Prose with a stray `|` and no delimiter row still splits normally.
+        let lines = vec![
+            "see foo | bar for details".to_string(),
+            "and another | line here".to_string(),
+        ];
+        assert!(should_split_plain_multiline_paste(&lines));
     }
 }

--- a/src/components/markdown/table.rs
+++ b/src/components/markdown/table.rs
@@ -13,11 +13,15 @@ use crate::theme::Theme;
 /// Horizontal alignment declared by the table's delimiter row.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TableColumnAlignment {
-    /// Left-aligned cells.
+    /// No explicit alignment marker (`---`). Renders left, but stays distinct
+    /// from [`Left`](Self::Left) so an unmarked column is not silently rewritten
+    /// with a leading colon on the next serialize.
+    Default,
+    /// Explicit left alignment (`:---`).
     Left,
-    /// Center-aligned cells.
+    /// Center-aligned cells (`:---:`).
     Center,
-    /// Right-aligned cells.
+    /// Right-aligned cells (`---:`).
     Right,
 }
 
@@ -82,7 +86,7 @@ impl TableData {
                     .collect::<Vec<_>>()
             })
             .collect::<Vec<_>>();
-        let alignments = vec![TableColumnAlignment::Left; columns];
+        let alignments = vec![TableColumnAlignment::Default; columns];
         Self {
             header,
             rows,
@@ -104,7 +108,7 @@ impl TableData {
             self.header.push(InlineTextTree::plain(String::new()));
         }
         while self.alignments.len() < columns {
-            self.alignments.push(TableColumnAlignment::Left);
+            self.alignments.push(TableColumnAlignment::Default);
         }
         for row in &mut self.rows {
             while row.len() < columns {
@@ -178,9 +182,11 @@ impl TableData {
     /// Removes one body row while preserving at least one body row.
     pub fn remove_body_row(&mut self, row_index: usize) {
         self.normalize_shape();
-        if self.rows.len() <= 1 || row_index >= self.rows.len() {
+        if row_index >= self.rows.len() {
             return;
         }
+        // A table may be left header-only; the editor removes the whole block
+        // when the header itself is then deleted.
         self.rows.remove(row_index);
     }
 
@@ -508,7 +514,13 @@ fn strip_table_indent(line: &str) -> Option<&str> {
 
 fn split_table_cells(line: &str) -> Option<Vec<String>> {
     let rest = strip_table_indent(line)?.trim_end();
-    let inner = rest.strip_prefix('|')?.strip_suffix('|')?;
+    if rest.is_empty() {
+        return None;
+    }
+    // Outer pipes are optional (GFM): strip them when present so pipeless rows
+    // like `Name | Score` split the same way as `| Name | Score |`.
+    let inner = rest.strip_prefix('|').unwrap_or(rest);
+    let inner = inner.strip_suffix('|').unwrap_or(inner);
     let mut cells = Vec::new();
     let mut current = String::new();
     let mut escaping = false;
@@ -559,13 +571,15 @@ fn parse_alignment_cell(cell: &str) -> Option<TableColumnAlignment> {
     Some(match (left, right) {
         (true, true) => TableColumnAlignment::Center,
         (false, true) => TableColumnAlignment::Right,
-        _ => TableColumnAlignment::Left,
+        (true, false) => TableColumnAlignment::Left,
+        (false, false) => TableColumnAlignment::Default,
     })
 }
 
 fn serialize_alignment(alignment: TableColumnAlignment) -> &'static str {
     match alignment {
-        TableColumnAlignment::Left => "---",
+        TableColumnAlignment::Default => "---",
+        TableColumnAlignment::Left => ":---",
         TableColumnAlignment::Center => ":---:",
         TableColumnAlignment::Right => "---:",
     }
@@ -592,6 +606,21 @@ pub fn is_table_candidate_line(line: &str) -> bool {
     strip_table_indent(line)
         .map(str::trim_end)
         .is_some_and(|rest| rest.starts_with('|'))
+}
+
+/// Number of pipe-separated cells in `line`, treating outer pipes as optional
+/// (GFM) so pipeless rows like `Name | Score` are recognized. Returns `None`
+/// for single-column lines so prose containing a stray `|` is not mistaken for
+/// a table row.
+pub fn table_row_column_count(line: &str) -> Option<usize> {
+    split_table_cells(line)
+        .map(|cells| cells.len())
+        .filter(|count| *count >= 2)
+}
+
+/// True when `line` could be a table row, including a pipeless GFM row.
+pub fn is_table_row_candidate(line: &str) -> bool {
+    table_row_column_count(line).is_some()
 }
 
 /// Collects a contiguous table-candidate region in the current container
@@ -623,10 +652,11 @@ pub fn parse_table_region(lines: &[String]) -> Option<TableData> {
 
     let mut rows = Vec::new();
     for line in &lines[2..] {
-        let cells = split_table_cells(line)?;
-        if cells.len() != header.len() {
-            return None;
-        }
+        // GFM normalizes body rows to the header width: short rows are padded
+        // with empty cells and long rows drop their trailing cells, instead of
+        // invalidating the whole table.
+        let mut cells = split_table_cells(line)?;
+        cells.resize(header.len(), String::new());
         rows.push(
             cells
                 .into_iter()
@@ -645,6 +675,39 @@ pub fn parse_table_region(lines: &[String]) -> Option<TableData> {
     })
 }
 
+/// Returns true when `line` is a delimiter row of exactly `columns` cells, each
+/// a valid alignment specifier.
+fn is_delimiter_row(line: &str, columns: usize) -> bool {
+    split_table_cells(line).is_some_and(|cells| {
+        cells.len() == columns
+            && cells
+                .iter()
+                .all(|cell| parse_alignment_cell(cell).is_some())
+    })
+}
+
+/// Detects a table that starts at `start` without requiring outer pipes,
+/// returning the region end (exclusive) when `lines[start]` is a multi-column
+/// header followed by a matching delimiter row. Body rows extend to the next
+/// blank line, matching GFM. Returns `None` for ordinary prose so a stray `|`
+/// is never mistaken for a table; single-column pipeless candidates are also
+/// rejected because they are ambiguous with setext headings.
+pub fn collect_pipeless_table_region(lines: &[String], start: usize) -> Option<usize> {
+    let header = split_table_cells(lines.get(start)?)?;
+    if header.len() < 2 {
+        return None;
+    }
+    if !is_delimiter_row(lines.get(start + 1)?, header.len()) {
+        return None;
+    }
+
+    let mut end = start + 2;
+    while end < lines.len() && !lines[end].trim().is_empty() {
+        end += 1;
+    }
+    Some(end)
+}
+
 /// Returns true when a root-level line is a candidate native table row.
 pub fn is_root_table_candidate_line(line: &str) -> bool {
     is_table_candidate_line(line)
@@ -658,6 +721,20 @@ pub fn collect_root_table_candidate_region(lines: &[String], start: usize) -> us
 /// Parses a root-level pipe table region into native table data.
 pub fn parse_root_table_region(lines: &[String]) -> Option<TableData> {
     parse_table_region(lines)
+}
+
+/// Parses a single table body row, normalized to `columns` cells (padded when
+/// short, truncated when long). Returns `None` when the line is not a table
+/// row at all.
+pub fn parse_table_body_row(line: &str, columns: usize) -> Option<Vec<InlineTextTree>> {
+    let mut cells = split_table_cells(line)?;
+    cells.resize(columns, String::new());
+    Some(
+        cells
+            .into_iter()
+            .map(|cell| InlineTextTree::from_markdown(&cell))
+            .collect(),
+    )
 }
 
 /// Serializes native table data to canonical pipe-table Markdown lines.
@@ -680,8 +757,9 @@ pub fn serialize_table_markdown_lines(table: &TableData) -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::{
-        TableColumnAlignment, TableColumnLayout, TableData, collect_root_table_candidate_region,
-        is_root_table_candidate_line, parse_root_table_region, serialize_table_markdown_lines,
+        TableColumnAlignment, TableColumnLayout, TableData, collect_pipeless_table_region,
+        collect_root_table_candidate_region, is_root_table_candidate_line, parse_root_table_region,
+        serialize_table_markdown_lines,
     };
     use crate::components::InlineTextTree;
 
@@ -720,6 +798,90 @@ mod tests {
     }
 
     #[test]
+    fn rejects_alignment_row_with_wrong_column_count() {
+        let lines = vec!["| A | B | C |".to_string(), "| --- | --- |".to_string()];
+        assert!(parse_root_table_region(&lines).is_none());
+    }
+
+    #[test]
+    fn preserves_explicit_left_alignment_colon() {
+        // ":---" is explicit left and must survive a parse/serialize round-trip
+        // instead of being silently rewritten to a bare "---".
+        let lines = vec![
+            "| L | D | R |".to_string(),
+            "| :--- | --- | ---: |".to_string(),
+            "| a | b | c |".to_string(),
+        ];
+        let table = parse_root_table_region(&lines).expect("table should parse");
+        assert_eq!(
+            table.alignments,
+            vec![
+                TableColumnAlignment::Left,
+                TableColumnAlignment::Default,
+                TableColumnAlignment::Right
+            ]
+        );
+        assert_eq!(
+            serialize_table_markdown_lines(&table)[1],
+            "| :--- | --- | ---: |"
+        );
+    }
+
+    #[test]
+    fn pads_short_body_rows_and_truncates_long_ones() {
+        let lines = vec![
+            "| A | B | C |".to_string(),
+            "| --- | --- | --- |".to_string(),
+            "| short |".to_string(),
+            "| 1 | 2 | 3 | 4 |".to_string(),
+        ];
+        let table = parse_root_table_region(&lines).expect("table should parse");
+        assert_eq!(table.rows.len(), 2);
+        assert_eq!(table.rows[0].len(), 3);
+        assert_eq!(table.rows[0][0].serialize_markdown(), "short");
+        assert!(table.rows[0][1].serialize_markdown().is_empty());
+        assert!(table.rows[0][2].serialize_markdown().is_empty());
+        assert_eq!(table.rows[1].len(), 3);
+        assert_eq!(table.rows[1][2].serialize_markdown(), "3");
+    }
+
+    #[test]
+    fn parses_pipeless_table() {
+        let lines = vec![
+            "Name | Score".to_string(),
+            "--- | ---".to_string(),
+            "Alice | 10".to_string(),
+            "Bob | 7".to_string(),
+        ];
+        let end = collect_pipeless_table_region(&lines, 0).expect("region");
+        assert_eq!(end, 4);
+        let table = parse_root_table_region(&lines[..end]).expect("table should parse");
+        assert_eq!(table.header.len(), 2);
+        assert_eq!(table.rows.len(), 2);
+        assert_eq!(table.header[0].serialize_markdown(), "Name");
+        assert_eq!(table.rows[1][1].serialize_markdown(), "7");
+    }
+
+    #[test]
+    fn prose_with_pipe_is_not_a_pipeless_table() {
+        let lines = vec!["this | that".to_string(), "and the next line".to_string()];
+        assert!(collect_pipeless_table_region(&lines, 0).is_none());
+    }
+
+    #[test]
+    fn pipeless_table_requires_valid_delimiter_row() {
+        let lines = vec!["Name | Score".to_string(), "Alice | 10".to_string()];
+        assert!(collect_pipeless_table_region(&lines, 0).is_none());
+    }
+
+    #[test]
+    fn single_column_pipeless_is_not_a_table() {
+        // Ambiguous with a setext heading; must not be captured as a table.
+        let lines = vec!["Title".to_string(), "---".to_string()];
+        assert!(collect_pipeless_table_region(&lines, 0).is_none());
+    }
+
+    #[test]
     fn serializes_canonical_pipe_table() {
         let table = TableData {
             header: vec![
@@ -730,7 +892,7 @@ mod tests {
                 InlineTextTree::plain("A | B".to_string()),
                 InlineTextTree::plain("value".to_string()),
             ]],
-            alignments: vec![TableColumnAlignment::Left, TableColumnAlignment::Right],
+            alignments: vec![TableColumnAlignment::Default, TableColumnAlignment::Right],
         };
         assert_eq!(
             serialize_table_markdown_lines(&table),
@@ -849,7 +1011,7 @@ mod tests {
     }
 
     #[test]
-    fn append_column_falls_back_to_left_when_alignments_are_missing() {
+    fn append_column_pads_missing_alignments_with_default() {
         let mut table = TableData {
             header: vec![InlineTextTree::plain("A".to_string())],
             rows: vec![vec![InlineTextTree::plain("1".to_string())]],
@@ -860,7 +1022,7 @@ mod tests {
 
         assert_eq!(
             table.alignments,
-            vec![TableColumnAlignment::Left, TableColumnAlignment::Left]
+            vec![TableColumnAlignment::Default, TableColumnAlignment::Left]
         );
         assert_eq!(table.header.len(), 2);
         assert_eq!(table.rows[0].len(), 2);
@@ -873,9 +1035,9 @@ mod tests {
         assert_eq!(
             table.alignments,
             vec![
-                TableColumnAlignment::Left,
+                TableColumnAlignment::Default,
                 TableColumnAlignment::Center,
-                TableColumnAlignment::Left
+                TableColumnAlignment::Default
             ]
         );
     }
@@ -926,12 +1088,16 @@ mod tests {
     }
 
     #[test]
-    fn remove_body_row_preserves_at_least_one_row() {
+    fn remove_body_row_can_empty_the_table() {
         let mut table = TableData::new_empty(2, 2);
         table.remove_body_row(0);
         assert_eq!(table.rows.len(), 1);
         table.remove_body_row(0);
-        assert_eq!(table.rows.len(), 1);
+        // The last body row can be removed, leaving a header-only table.
+        assert!(table.rows.is_empty());
+        // Out-of-range removal is a no-op.
+        table.remove_body_row(0);
+        assert!(table.rows.is_empty());
     }
 
     #[test]

--- a/src/editor/context_menu.rs
+++ b/src/editor/context_menu.rs
@@ -5,9 +5,7 @@ use std::time::Duration;
 use gpui::*;
 
 use super::{Editor, TableAxisSelection, ViewMode};
-use crate::components::{
-    BlockRecord, DismissTransientUi, TableAxisKind, TableColumnAlignment, TableData,
-};
+use crate::components::{DismissTransientUi, TableAxisKind, TableColumnAlignment, TableData};
 use crate::i18n::I18nManager;
 use crate::theme::Theme;
 
@@ -398,21 +396,7 @@ impl Editor {
         // A table inserted as the last block in its container leaves no line
         // below it, so in rendered mode the caret cannot move past the table.
         // Add a trailing empty paragraph to land on when nothing follows it.
-        if let Some(location) = self.document.find_block_location(new_block.entity_id()) {
-            let sibling_count = match location.parent.as_ref() {
-                Some(parent) => parent.read(cx).children.len(),
-                None => self.document.root_count(),
-            };
-            if location.index + 1 >= sibling_count {
-                let trailing = Self::new_block(cx, BlockRecord::paragraph(String::new()));
-                self.document.insert_blocks_at(
-                    location.parent,
-                    location.index + 1,
-                    vec![trailing],
-                    cx,
-                );
-            }
-        }
+        self.ensure_trailing_paragraph_after_structural(&new_block, cx);
 
         self.rebuild_table_runtimes(cx);
         if let Some(first_cell) = new_block
@@ -459,7 +443,10 @@ impl Editor {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.on_apply_column_alignment(TableColumnAlignment::Left, cx);
+        // Left is the default, so emit the unmarked `---` form rather than an
+        // explicit `:---`; an explicit colon is only kept when the source had
+        // one. This keeps the menu's output unchanged from before.
+        self.on_apply_column_alignment(TableColumnAlignment::Default, cx);
     }
 
     pub(super) fn on_align_table_column_center(
@@ -591,10 +578,22 @@ impl Editor {
         let Some(table_block) = self.table_block_by_id(selection.table_block_id, cx) else {
             return;
         };
+        let row_count = table_block
+            .read(cx)
+            .record
+            .table
+            .as_ref()
+            .map(|table| table.rows.len());
         self.close_context_menu(cx);
-        // Visual index 0 is the header: deleting it promotes the first body row.
+        // Visual index 0 is the header: deleting it promotes the first body row,
+        // unless there is no body row left, in which case it was the table's last
+        // row and the whole table is removed.
         if selection.index == 0 {
-            self.delete_table_header_row(&table_block, cx);
+            if row_count == Some(0) {
+                self.remove_table_block(&table_block, cx);
+            } else {
+                self.delete_table_header_row(&table_block, cx);
+            }
         } else {
             self.delete_table_row(&table_block, selection.index - 1, cx);
         }
@@ -629,8 +628,19 @@ impl Editor {
         let Some(table_block) = self.table_block_by_id(selection.table_block_id, cx) else {
             return;
         };
+        let column_count = table_block
+            .read(cx)
+            .record
+            .table
+            .as_ref()
+            .map(|table| table.column_count());
         self.close_context_menu(cx);
-        self.delete_table_column(&table_block, selection.index, cx);
+        // Removing the only column empties the table, so drop the whole block.
+        if column_count == Some(1) {
+            self.remove_table_block(&table_block, cx);
+        } else {
+            self.delete_table_column(&table_block, selection.index, cx);
+        }
     }
 
     fn render_axis_menu_item(
@@ -881,7 +891,9 @@ impl Editor {
                             theme,
                             "table-axis-delete-column",
                             s.table_axis_delete_column.clone(),
-                            table.column_count() > 1,
+                            // Always enabled: deleting the last column removes the
+                            // whole table.
+                            true,
                             true,
                             Self::on_delete_table_column,
                             cx,
@@ -950,19 +962,14 @@ impl Editor {
                                 .bg(c.dialog_border)
                                 .into_any_element(),
                         );
-                        // Deleting the header (index 0) promotes the first body
-                        // row, so it only needs one body row; deleting a body row
-                        // must leave at least one behind.
-                        let delete_enabled = if selection.index == 0 {
-                            !table.rows.is_empty()
-                        } else {
-                            table.rows.len() > 1
-                        };
+                        // Always enabled: deleting the header promotes the first
+                        // body row, and deleting the last remaining row removes
+                        // the whole table.
                         items.push(Self::render_axis_menu_item(
                             theme,
                             "table-axis-delete-row",
                             s.table_axis_delete_row.clone(),
-                            delete_enabled,
+                            true,
                             true,
                             Self::on_delete_table_row,
                             cx,

--- a/src/editor/document.rs
+++ b/src/editor/document.rs
@@ -13,9 +13,9 @@ use crate::components::{
 };
 use crate::components::{HtmlSafetyClass, parse_html_document};
 use crate::components::{
-    collect_root_table_candidate_region, collect_table_candidate_region,
-    is_root_table_candidate_line, is_table_candidate_line, parse_root_table_region,
-    parse_standalone_image, parse_table_region,
+    collect_pipeless_table_region, collect_root_table_candidate_region,
+    collect_table_candidate_region, is_root_table_candidate_line, is_table_candidate_line,
+    parse_root_table_region, parse_standalone_image, parse_table_region,
 };
 use crate::components::{is_mermaid_info_string, parse_display_math_source};
 
@@ -1107,6 +1107,14 @@ impl Editor {
                             .map(|line| plain_text_paragraph_block(cx, line)),
                     );
                 }
+                index = end;
+                continue;
+            }
+
+            if let Some(end) = collect_pipeless_table_region(lines, index)
+                && let Some(table) = parse_root_table_region(&lines[index..end])
+            {
+                roots.push(Self::new_block(cx, BlockRecord::table(table)));
                 index = end;
                 continue;
             }

--- a/src/editor/events.rs
+++ b/src/editor/events.rs
@@ -15,7 +15,8 @@ use gpui::*;
 use super::Editor;
 use crate::components::{
     BlockEvent, BlockKind, BlockRecord, CollapsedCaretAffinity, IndentBlock, InlineTextTree,
-    OutdentBlock, PastedImageSource, TableCellPosition,
+    OutdentBlock, PastedImageSource, TableCellPosition, is_table_row_candidate,
+    parse_root_table_region, parse_table_body_row,
 };
 use crate::config::{ImagePasteBehavior, read_app_preferences};
 
@@ -645,6 +646,251 @@ impl Editor {
             block.cursor_blink_epoch = Instant::now();
             cx.notify();
         });
+    }
+
+    /// A block that a setext underline below it can promote into a heading: a
+    /// non-empty, single-line, plain paragraph with no children.
+    fn is_setext_heading_target(block: &Entity<super::Block>, cx: &App) -> bool {
+        let block = block.read(cx);
+        if block.kind() != BlockKind::Paragraph || !block.children.is_empty() {
+            return false;
+        }
+        let text = block.record.title.visible_text();
+        !text.trim().is_empty() && !text.contains('\n')
+    }
+
+    /// Handles Enter pressed on a paragraph that is a pure setext underline.
+    /// When a matching paragraph precedes it at the root, the two collapse into
+    /// a heading; a lone dash run still falls back to a thematic break. Returns
+    /// true when it consumed the newline.
+    fn try_form_setext_heading_on_newline(
+        &mut self,
+        block: &Entity<super::Block>,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let text = block.read(cx).display_text().to_string();
+        let Some(level) = BlockKind::parse_setext_underline(&text) else {
+            return false;
+        };
+        if block.read(cx).kind() != BlockKind::Paragraph {
+            return false;
+        }
+        let Some(location) = self.document.find_block_location(block.entity_id()) else {
+            return false;
+        };
+
+        // Only root paragraphs auto-form headings; nested contexts (quotes,
+        // lists) keep their existing newline behavior.
+        let target = if location.parent.is_none() {
+            self.document
+                .previous_sibling(block.entity_id(), cx)
+                .filter(|prev| Self::is_setext_heading_target(prev, cx))
+        } else {
+            None
+        };
+
+        // A `=` underline with no heading target is ordinary text: defer to the
+        // normal newline split. A dash run still has to become a separator.
+        if target.is_none() && !BlockKind::parse_separator_line(&text) {
+            return false;
+        }
+
+        // The newline's own capture was already finalized by the block's Changed
+        // event (nothing had changed yet), so start a fresh one here that spans
+        // the heading/separator conversion. prepare is a no-op if one is pending.
+        self.prepare_undo_capture(crate::components::UndoCaptureKind::NonCoalescible, cx);
+
+        if let Some(prev) = target {
+            let heading_title = prev.read(cx).record.title.clone();
+            let cursor = heading_title.visible_len();
+            let removed_id = block.entity_id();
+            let new_paragraph = Self::new_block(cx, BlockRecord::paragraph(String::new()));
+
+            Self::set_block_title_and_kind(
+                &prev,
+                BlockKind::Heading { level },
+                heading_title,
+                cursor,
+                cx,
+            );
+            self.document.with_structure_mutation(cx, |document, cx| {
+                let _ = document.remove_block_by_id_raw(removed_id, cx);
+            });
+            if let Some(heading_location) = self.document.find_block_location(prev.entity_id()) {
+                self.document.insert_blocks_at(
+                    heading_location.parent,
+                    heading_location.index + 1,
+                    vec![new_paragraph.clone()],
+                    cx,
+                );
+            }
+            self.focus_block(new_paragraph.entity_id());
+        } else {
+            block.update(cx, |block, _cx| block.make_separator());
+            let new_paragraph = Self::new_block(cx, BlockRecord::paragraph(String::new()));
+            self.document.insert_blocks_at(
+                location.parent,
+                location.index + 1,
+                vec![new_paragraph.clone()],
+                cx,
+            );
+            self.focus_block(new_paragraph.entity_id());
+        }
+
+        self.rebuild_image_runtimes(cx);
+        self.mark_dirty(cx);
+        self.finalize_pending_undo_capture(cx);
+        cx.notify();
+        true
+    }
+
+    /// Handles Enter pressed on a paragraph that is a pipe-table row. A
+    /// delimiter row under a header paragraph forms a native table; a body row
+    /// directly under an existing table is absorbed into it. After either, the
+    /// caret lands in a fresh paragraph below the table so consecutive rows can
+    /// be typed. Returns true when it consumed the newline.
+    fn try_form_or_extend_table_on_newline(
+        &mut self,
+        block: &Entity<super::Block>,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        let text = block.read(cx).display_text().to_string();
+        if block.read(cx).kind() != BlockKind::Paragraph || !is_table_row_candidate(&text) {
+            return false;
+        }
+        let Some(location) = self.document.find_block_location(block.entity_id()) else {
+            return false;
+        };
+        if location.parent.is_some() {
+            return false;
+        }
+        let Some(prev) = self.document.previous_sibling(block.entity_id(), cx) else {
+            return false;
+        };
+
+        if prev.read(cx).kind() == BlockKind::Table {
+            // A multi-column row typed directly under a table is meant as a row,
+            // so absorb it and let the table normalize ragged cell counts the
+            // same way pasted rows are padded or truncated to the header width.
+            return self.extend_table_with_typed_row(&prev, block, &text, cx);
+        }
+
+        if prev.read(cx).kind() != BlockKind::Paragraph {
+            return false;
+        }
+        let header_text = prev.read(cx).display_text().to_string();
+        if !is_table_row_candidate(&header_text) {
+            return false;
+        }
+        let Some(table) = parse_root_table_region(&[header_text, text]) else {
+            return false;
+        };
+
+        self.prepare_undo_capture(crate::components::UndoCaptureKind::NonCoalescible, cx);
+        // Remove the lower (delimiter) block first so the header index is stable.
+        let header_index = location.index - 1;
+        let removed_delimiter = block.entity_id();
+        let removed_header = prev.entity_id();
+        let table_block = Self::new_table_block(cx, table);
+        let new_paragraph = Self::new_block(cx, BlockRecord::paragraph(String::new()));
+        self.document.with_structure_mutation(cx, |document, cx| {
+            let _ = document.remove_block_by_id_raw(removed_delimiter, cx);
+            let _ = document.remove_block_by_id_raw(removed_header, cx);
+        });
+        self.document.insert_blocks_at(
+            None,
+            header_index,
+            vec![table_block.clone(), new_paragraph.clone()],
+            cx,
+        );
+        self.rebuild_table_runtimes(cx);
+        self.focus_block(new_paragraph.entity_id());
+        self.mark_dirty(cx);
+        self.finalize_pending_undo_capture(cx);
+        cx.notify();
+        true
+    }
+
+    fn extend_table_with_typed_row(
+        &mut self,
+        table_block: &Entity<super::Block>,
+        row_block: &Entity<super::Block>,
+        text: &str,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        // Capture any in-progress cell edits before mutating the record.
+        self.sync_table_record_from_runtime(table_block, cx);
+        let Some(mut table) = table_block.read(cx).record.table.clone() else {
+            return false;
+        };
+        let Some(row) = parse_table_body_row(text, table.column_count()) else {
+            return false;
+        };
+
+        self.prepare_undo_capture(crate::components::UndoCaptureKind::NonCoalescible, cx);
+        table.rows.push(row);
+        table_block.update(cx, |block, cx| {
+            block.record.table = Some(table);
+            cx.notify();
+        });
+
+        let removed_id = row_block.entity_id();
+        self.document.with_structure_mutation(cx, |document, cx| {
+            let _ = document.remove_block_by_id_raw(removed_id, cx);
+        });
+        let new_paragraph = Self::new_block(cx, BlockRecord::paragraph(String::new()));
+        if let Some(table_location) = self.document.find_block_location(table_block.entity_id()) {
+            self.document.insert_blocks_at(
+                table_location.parent,
+                table_location.index + 1,
+                vec![new_paragraph.clone()],
+                cx,
+            );
+        }
+        self.rebuild_table_runtimes(cx);
+        self.focus_block(new_paragraph.entity_id());
+        self.mark_dirty(cx);
+        self.finalize_pending_undo_capture(cx);
+        cx.notify();
+        true
+    }
+
+    /// Inserts an empty paragraph after `block` when it renders as a
+    /// self-contained structure the caret cannot move past (table, code, math,
+    /// separator, quote, callout, footnote definition, standalone image, ...)
+    /// and nothing currently follows it in its container. This keeps a rendered
+    /// document from ending on such a block, so a rendered-first user can keep
+    /// typing past it rather than being stranded. No-op when something already
+    /// follows the block or it is not a stranding structure.
+    pub(super) fn ensure_trailing_paragraph_after_structural(
+        &mut self,
+        block: &Entity<super::Block>,
+        cx: &mut Context<Self>,
+    ) {
+        let strands = {
+            let block = block.read(cx);
+            let kind = block.kind();
+            kind.is_atomic_structural()
+                || kind.is_quote_container()
+                || kind.is_footnote_definition()
+                || block.renders_as_standalone_image()
+        };
+        if !strands {
+            return;
+        }
+        let Some(location) = self.document.find_block_location(block.entity_id()) else {
+            return;
+        };
+        let sibling_count = match location.parent.as_ref() {
+            Some(parent) => parent.read(cx).children.len(),
+            None => self.document.root_count(),
+        };
+        if location.index + 1 < sibling_count {
+            return;
+        }
+        let trailing = Self::new_block(cx, BlockRecord::paragraph(String::new()));
+        self.document
+            .insert_blocks_at(location.parent, location.index + 1, vec![trailing], cx);
     }
 
     fn apply_paragraph_shortcuts(
@@ -1410,6 +1656,17 @@ impl Editor {
                 trailing,
                 source_already_mutated,
             } => {
+                // Typing a setext underline (`=====`/`-----`) under a paragraph
+                // and pressing Enter turns that paragraph into a heading, the
+                // same way the importer treats the two adjacent lines.
+                if self.try_form_setext_heading_on_newline(&block, cx) {
+                    return;
+                }
+                // Typing a delimiter row under a header forms a native table,
+                // and typing further pipe rows below the table absorbs them.
+                if self.try_form_or_extend_table_on_newline(&block, cx) {
+                    return;
+                }
                 let Some(location) = self.document.find_block_location(block.entity_id()) else {
                     return;
                 };
@@ -1629,6 +1886,18 @@ impl Editor {
                 );
                 self.rebuild_table_runtimes(cx);
 
+                // A structural block pasted at the very end of the document leaves
+                // no line below it; remember that so a trailing paragraph can be
+                // added once the paste (and any quote normalization) settles.
+                let inserted_at_doc_end = inserted_roots.last().is_some_and(|last| {
+                    self.document
+                        .find_block_location(last.entity_id())
+                        .is_some_and(|location| {
+                            location.parent.is_none()
+                                && location.index + 1 >= self.document.root_count()
+                        })
+                });
+
                 if let Some(last_root) = inserted_roots.last() {
                     let focus_block = if last_root.read(cx).kind() == BlockKind::Table {
                         last_root
@@ -1680,6 +1949,14 @@ impl Editor {
 
                 if quote_related {
                     self.normalize_rendered_quote_structure(cx);
+                }
+
+                // Quote normalization rebuilds roots from Markdown, so resolve the
+                // landing block from the live tree rather than the pasted handles.
+                if inserted_at_doc_end {
+                    if let Some(last_root) = self.document.root_blocks().last().cloned() {
+                        self.ensure_trailing_paragraph_after_structural(&last_root, cx);
+                    }
                 }
                 self.mark_dirty(cx);
                 self.finalize_pending_undo_capture(cx);
@@ -2515,6 +2792,345 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn setext_equals_underline_enter_promotes_previous_paragraph_to_h1(
+        cx: &mut TestAppContext,
+    ) {
+        let cx = cx.add_empty_window();
+        let editor = cx.new(|cx| Editor::from_markdown(cx, "Title\n\n=====".to_string(), None));
+
+        cx.update(|window, cx| {
+            editor.update(cx, |editor, cx| {
+                let underline = editor.document.visible_blocks()[1].entity.clone();
+                underline.update(cx, |block, block_cx| {
+                    block.move_to(block.visible_len(), block_cx);
+                    block.on_newline(&Newline, window, block_cx);
+                });
+            });
+        });
+
+        editor.update(cx, |editor, cx| {
+            let visible = editor.document.visible_blocks();
+            assert_eq!(visible.len(), 2);
+            assert_eq!(
+                visible[0].entity.read(cx).kind(),
+                BlockKind::Heading { level: 1 }
+            );
+            assert_eq!(visible[0].entity.read(cx).display_text(), "Title");
+            assert_eq!(visible[1].entity.read(cx).kind(), BlockKind::Paragraph);
+            assert_eq!(visible[1].entity.read(cx).display_text(), "");
+            assert_eq!(editor.document.markdown_text(cx), "# Title\n\n");
+        });
+
+        // Reversible: undo restores the two original paragraphs.
+        editor.update(cx, |editor, cx| {
+            editor.undo_document(cx);
+            assert_eq!(editor.document.markdown_text(cx), "Title\n\n=====");
+        });
+    }
+
+    #[gpui::test]
+    async fn setext_dash_underline_enter_promotes_previous_paragraph_to_h2(
+        cx: &mut TestAppContext,
+    ) {
+        let cx = cx.add_empty_window();
+        // A bare "-----" in source parses as a thematic break, so simulate the
+        // user typing the underline into the paragraph below the title instead.
+        let editor = cx.new(|cx| Editor::from_markdown(cx, "Title\n\nx".to_string(), None));
+
+        cx.update(|window, cx| {
+            editor.update(cx, |editor, cx| {
+                let underline = editor.document.visible_blocks()[1].entity.clone();
+                underline.update(cx, |block, block_cx| {
+                    let end = block.visible_len();
+                    block.replace_text_in_visible_range(0..end, "-----", None, false, block_cx);
+                    block.move_to(block.visible_len(), block_cx);
+                    block.on_newline(&Newline, window, block_cx);
+                });
+            });
+        });
+
+        editor.update(cx, |editor, cx| {
+            let visible = editor.document.visible_blocks();
+            assert_eq!(
+                visible[0].entity.read(cx).kind(),
+                BlockKind::Heading { level: 2 }
+            );
+            assert_eq!(visible[0].entity.read(cx).display_text(), "Title");
+            assert_eq!(editor.document.markdown_text(cx), "## Title\n\n");
+        });
+    }
+
+    #[gpui::test]
+    async fn dash_underline_without_heading_target_stays_a_separator(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let editor = cx.new(|cx| Editor::from_markdown(cx, String::new(), None));
+
+        cx.update(|window, cx| {
+            editor.update(cx, |editor, cx| {
+                let block = editor.document.visible_blocks()[0].entity.clone();
+                block.update(cx, |block, block_cx| {
+                    block.replace_text_in_visible_range(0..0, "-----", None, false, block_cx);
+                    block.move_to(block.visible_len(), block_cx);
+                    block.on_newline(&Newline, window, block_cx);
+                });
+            });
+        });
+
+        editor.update(cx, |editor, cx| {
+            let visible = editor.document.visible_blocks();
+            assert_eq!(visible[0].entity.read(cx).kind(), BlockKind::Separator);
+        });
+    }
+
+    #[gpui::test]
+    async fn equals_underline_without_heading_target_stays_a_paragraph(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let editor = cx.new(|cx| Editor::from_markdown(cx, String::new(), None));
+
+        cx.update(|window, cx| {
+            editor.update(cx, |editor, cx| {
+                let block = editor.document.visible_blocks()[0].entity.clone();
+                block.update(cx, |block, block_cx| {
+                    block.replace_text_in_visible_range(0..0, "=====", None, false, block_cx);
+                    block.move_to(block.visible_len(), block_cx);
+                    block.on_newline(&Newline, window, block_cx);
+                });
+            });
+        });
+
+        editor.update(cx, |editor, cx| {
+            let visible = editor.document.visible_blocks();
+            assert_eq!(visible[0].entity.read(cx).kind(), BlockKind::Paragraph);
+            assert_eq!(visible[0].entity.read(cx).display_text(), "=====");
+        });
+    }
+
+    #[gpui::test]
+    async fn delimiter_row_enter_forms_native_table(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let editor = cx.new(|cx| {
+            Editor::from_markdown(cx, "| Name | Score |\n\n| --- | --- |".to_string(), None)
+        });
+
+        cx.update(|window, cx| {
+            editor.update(cx, |editor, cx| {
+                let delimiter = editor.document.root_blocks()[1].clone();
+                delimiter.update(cx, |block, block_cx| {
+                    block.move_to(block.visible_len(), block_cx);
+                    block.on_newline(&Newline, window, block_cx);
+                });
+            });
+        });
+
+        editor.update(cx, |editor, cx| {
+            let roots = editor.document.root_blocks();
+            assert_eq!(roots.len(), 2);
+            assert_eq!(roots[0].read(cx).kind(), BlockKind::Table);
+            let table = roots[0].read(cx).record.table.clone().expect("table");
+            assert_eq!(table.header.len(), 2);
+            assert_eq!(table.header[0].serialize_markdown(), "Name");
+            assert!(table.rows.is_empty());
+            assert_eq!(roots[1].read(cx).kind(), BlockKind::Paragraph);
+            assert_eq!(
+                editor.document.markdown_text(cx),
+                "| Name | Score |\n| --- | --- |\n\n"
+            );
+        });
+
+        // Reversible in one step back to the two source paragraphs.
+        editor.update(cx, |editor, cx| {
+            editor.undo_document(cx);
+            assert_eq!(
+                editor.document.markdown_text(cx),
+                "| Name | Score |\n\n| --- | --- |"
+            );
+        });
+    }
+
+    #[gpui::test]
+    async fn pipe_row_below_table_is_absorbed_as_a_row(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let editor = cx.new(|cx| {
+            Editor::from_markdown(cx, "| Name | Score |\n\n| --- | --- |".to_string(), None)
+        });
+
+        // Form the table.
+        cx.update(|window, cx| {
+            editor.update(cx, |editor, cx| {
+                let delimiter = editor.document.root_blocks()[1].clone();
+                delimiter.update(cx, |block, block_cx| {
+                    block.move_to(block.visible_len(), block_cx);
+                    block.on_newline(&Newline, window, block_cx);
+                });
+            });
+        });
+
+        // Type a body row into the paragraph below the table and press Enter.
+        cx.update(|window, cx| {
+            editor.update(cx, |editor, cx| {
+                let row = editor.document.root_blocks()[1].clone();
+                row.update(cx, |block, block_cx| {
+                    block.replace_text_in_visible_range(
+                        0..0,
+                        "| Alice | 10 |",
+                        None,
+                        false,
+                        block_cx,
+                    );
+                    block.move_to(block.visible_len(), block_cx);
+                    block.on_newline(&Newline, window, block_cx);
+                });
+            });
+        });
+
+        editor.update(cx, |editor, cx| {
+            let roots = editor.document.root_blocks();
+            assert_eq!(roots[0].read(cx).kind(), BlockKind::Table);
+            let table = roots[0].read(cx).record.table.clone().expect("table");
+            assert_eq!(table.rows.len(), 1);
+            assert_eq!(table.rows[0][0].serialize_markdown(), "Alice");
+            assert_eq!(table.rows[0][1].serialize_markdown(), "10");
+            assert_eq!(roots[1].read(cx).kind(), BlockKind::Paragraph);
+            assert_eq!(roots[1].read(cx).display_text(), "");
+        });
+    }
+
+    #[gpui::test]
+    async fn pipeless_delimiter_row_enter_forms_native_table(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let editor =
+            cx.new(|cx| Editor::from_markdown(cx, "Name | Score\n\n---- | ----".to_string(), None));
+
+        cx.update(|window, cx| {
+            editor.update(cx, |editor, cx| {
+                let delimiter = editor.document.root_blocks()[1].clone();
+                delimiter.update(cx, |block, block_cx| {
+                    block.move_to(block.visible_len(), block_cx);
+                    block.on_newline(&Newline, window, block_cx);
+                });
+            });
+        });
+
+        editor.update(cx, |editor, cx| {
+            let roots = editor.document.root_blocks();
+            assert_eq!(roots.len(), 2);
+            assert_eq!(roots[0].read(cx).kind(), BlockKind::Table);
+            let table = roots[0].read(cx).record.table.clone().expect("table");
+            assert_eq!(table.header.len(), 2);
+            assert_eq!(table.header[0].serialize_markdown(), "Name");
+            assert_eq!(table.header[1].serialize_markdown(), "Score");
+            assert!(table.rows.is_empty());
+            assert_eq!(roots[1].read(cx).kind(), BlockKind::Paragraph);
+        });
+    }
+
+    #[gpui::test]
+    async fn pipeless_row_below_table_is_absorbed_as_a_row(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let editor =
+            cx.new(|cx| Editor::from_markdown(cx, "Name | Score\n\n---- | ----".to_string(), None));
+
+        cx.update(|window, cx| {
+            editor.update(cx, |editor, cx| {
+                let delimiter = editor.document.root_blocks()[1].clone();
+                delimiter.update(cx, |block, block_cx| {
+                    block.move_to(block.visible_len(), block_cx);
+                    block.on_newline(&Newline, window, block_cx);
+                });
+            });
+        });
+
+        // A pipeless body row with the table's column count is absorbed.
+        cx.update(|window, cx| {
+            editor.update(cx, |editor, cx| {
+                let row = editor.document.root_blocks()[1].clone();
+                row.update(cx, |block, block_cx| {
+                    block.replace_text_in_visible_range(0..0, "Alice | 10", None, false, block_cx);
+                    block.move_to(block.visible_len(), block_cx);
+                    block.on_newline(&Newline, window, block_cx);
+                });
+            });
+        });
+
+        editor.update(cx, |editor, cx| {
+            let roots = editor.document.root_blocks();
+            assert_eq!(roots[0].read(cx).kind(), BlockKind::Table);
+            let table = roots[0].read(cx).record.table.clone().expect("table");
+            assert_eq!(table.rows.len(), 1);
+            assert_eq!(table.rows[0][0].serialize_markdown(), "Alice");
+            assert_eq!(table.rows[0][1].serialize_markdown(), "10");
+            assert_eq!(roots[1].read(cx).kind(), BlockKind::Paragraph);
+        });
+    }
+
+    #[gpui::test]
+    async fn ragged_pipeless_row_below_table_is_padded_to_width(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let editor = cx
+            .new(|cx| Editor::from_markdown(cx, "A | B | C\n\n--- | --- | ---".to_string(), None));
+
+        cx.update(|window, cx| {
+            editor.update(cx, |editor, cx| {
+                let delimiter = editor.document.root_blocks()[1].clone();
+                delimiter.update(cx, |block, block_cx| {
+                    block.move_to(block.visible_len(), block_cx);
+                    block.on_newline(&Newline, window, block_cx);
+                });
+            });
+        });
+
+        // Two cells typed under a three-column table: absorbed as a row and
+        // padded to the header width, matching how pasted ragged rows behave.
+        cx.update(|window, cx| {
+            editor.update(cx, |editor, cx| {
+                let row = editor.document.root_blocks()[1].clone();
+                row.update(cx, |block, block_cx| {
+                    block.replace_text_in_visible_range(0..0, "one | two", None, false, block_cx);
+                    block.move_to(block.visible_len(), block_cx);
+                    block.on_newline(&Newline, window, block_cx);
+                });
+            });
+        });
+
+        editor.update(cx, |editor, cx| {
+            let table = editor.document.root_blocks()[0]
+                .read(cx)
+                .record
+                .table
+                .clone()
+                .expect("table");
+            assert_eq!(table.rows.len(), 1);
+            assert_eq!(table.rows[0].len(), 3);
+            assert_eq!(table.rows[0][0].serialize_markdown(), "one");
+            assert_eq!(table.rows[0][1].serialize_markdown(), "two");
+            assert_eq!(table.rows[0][2].serialize_markdown(), "");
+        });
+    }
+
+    #[gpui::test]
+    async fn lone_pipe_row_without_table_context_stays_a_paragraph(cx: &mut TestAppContext) {
+        let cx = cx.add_empty_window();
+        let editor = cx.new(|cx| Editor::from_markdown(cx, String::new(), None));
+
+        cx.update(|window, cx| {
+            editor.update(cx, |editor, cx| {
+                let block = editor.document.root_blocks()[0].clone();
+                block.update(cx, |block, block_cx| {
+                    block.replace_text_in_visible_range(0..0, "| a | b |", None, false, block_cx);
+                    block.move_to(block.visible_len(), block_cx);
+                    block.on_newline(&Newline, window, block_cx);
+                });
+            });
+        });
+
+        editor.update(cx, |editor, cx| {
+            let roots = editor.document.root_blocks();
+            assert_eq!(roots[0].read(cx).kind(), BlockKind::Paragraph);
+            assert_eq!(roots[0].read(cx).display_text(), "| a | b |");
+        });
+    }
+
+    #[gpui::test]
     async fn math_block_exit_shortcut_creates_plain_text_block(cx: &mut TestAppContext) {
         let cx = cx.add_empty_window();
         let editor = cx.new(|cx| Editor::from_markdown(cx, "$$n^2$$".to_string(), None));
@@ -3012,9 +3628,11 @@ mod tests {
 
             // The header row must survive: previously the first pasted line was
             // folded into the paragraph, leaving the alignment row to masquerade
-            // as the header. The empty paste target is also dropped.
+            // as the header. The empty paste target is also dropped, and a
+            // trailing paragraph is added so the document does not end on the
+            // table with no line below it.
             let visible = editor.document.visible_blocks();
-            assert_eq!(visible.len(), 1);
+            assert_eq!(visible.len(), 2);
             let table = visible[0].entity.read(cx);
             assert_eq!(table.kind(), BlockKind::Table);
             let data = table.record.table.as_ref().expect("table data");
@@ -3023,6 +3641,8 @@ mod tests {
             assert_eq!(data.rows.len(), 1);
             assert_eq!(data.rows[0][0].serialize_markdown(), "1");
             assert_eq!(data.rows[0][1].serialize_markdown(), "2");
+            assert_eq!(visible[1].entity.read(cx).kind(), BlockKind::Paragraph);
+            assert_eq!(visible[1].entity.read(cx).display_text(), "");
         });
     }
 
@@ -3050,9 +3670,10 @@ mod tests {
             // The fence is structural, so the whole paste goes through the block
             // importer rather than the plain-text path: the opening ```rust line is
             // no longer folded into a paragraph, and the empty paste target is
-            // dropped, leaving a single native code block.
+            // dropped. A trailing paragraph is added so the document does not end
+            // on the code block with no line below it.
             let visible = editor.document.visible_blocks();
-            assert_eq!(visible.len(), 1);
+            assert_eq!(visible.len(), 2);
             let code = visible[0].entity.read(cx);
             assert_eq!(
                 code.kind(),
@@ -3061,9 +3682,10 @@ mod tests {
                 }
             );
             assert_eq!(code.display_text(), "fn main() {}");
+            assert_eq!(visible[1].entity.read(cx).kind(), BlockKind::Paragraph);
             assert_eq!(
                 editor.document.markdown_text(cx),
-                "```rust\nfn main() {}\n```"
+                "```rust\nfn main() {}\n```\n\n"
             );
         });
     }
@@ -3137,6 +3759,166 @@ mod tests {
             assert_eq!(visible[1].entity.read(cx).display_text(), "fn main() {}");
             assert_eq!(visible[2].entity.read(cx).kind(), BlockKind::Paragraph);
             assert_eq!(visible[2].entity.read(cx).display_text(), "after");
+            // Text already follows the code block, so no extra trailing
+            // paragraph is added mid-document.
+        });
+    }
+
+    #[gpui::test]
+    async fn structural_paste_at_document_end_adds_one_trailing_paragraph(cx: &mut TestAppContext) {
+        let editor = cx.new(|cx| Editor::from_markdown(cx, "intro".into(), None));
+
+        editor.update(cx, |editor, cx| {
+            let block = editor.document.visible_blocks()[0].entity.clone();
+            block.update(cx, |block, _cx| {
+                block.selected_range = block.visible_len()..block.visible_len();
+            });
+            editor.on_block_event(
+                block,
+                &BlockEvent::RequestPasteMultiline {
+                    leading: InlineTextTree::plain("intro"),
+                    lines: vec!["***".to_string()],
+                    trailing: InlineTextTree::plain(String::new()),
+                    split_physical_lines: false,
+                },
+                cx,
+            );
+
+            let visible = editor.document.visible_blocks();
+            assert_eq!(visible.len(), 3);
+            assert_eq!(visible[0].entity.read(cx).display_text(), "intro");
+            assert_eq!(visible[1].entity.read(cx).kind(), BlockKind::Separator);
+            assert_eq!(visible[2].entity.read(cx).kind(), BlockKind::Paragraph);
+            assert_eq!(visible[2].entity.read(cx).display_text(), "");
+        });
+    }
+
+    #[gpui::test]
+    async fn structural_paste_of_quote_at_document_end_adds_trailing_paragraph(
+        cx: &mut TestAppContext,
+    ) {
+        let editor = cx.new(|cx| Editor::from_markdown(cx, "intro".into(), None));
+
+        editor.update(cx, |editor, cx| {
+            let block = editor.document.visible_blocks()[0].entity.clone();
+            block.update(cx, |block, _cx| {
+                block.selected_range = block.visible_len()..block.visible_len();
+            });
+            editor.on_block_event(
+                block,
+                &BlockEvent::RequestPasteMultiline {
+                    leading: InlineTextTree::plain("intro"),
+                    lines: vec!["> quoted".to_string()],
+                    trailing: InlineTextTree::plain(String::new()),
+                    split_physical_lines: false,
+                },
+                cx,
+            );
+
+            // The quote container cannot hold the caret below it, so a trailing
+            // paragraph is added even though quote normalization re-parses the
+            // whole document on the way.
+            let roots = editor.document.root_blocks();
+            assert_eq!(roots.len(), 3);
+            assert_eq!(roots[0].read(cx).display_text(), "intro");
+            assert_eq!(roots[1].read(cx).kind(), BlockKind::Quote);
+            assert_eq!(roots[2].read(cx).kind(), BlockKind::Paragraph);
+            assert_eq!(roots[2].read(cx).display_text(), "");
+        });
+    }
+
+    #[gpui::test]
+    async fn structural_paste_of_callout_at_document_end_adds_trailing_paragraph(
+        cx: &mut TestAppContext,
+    ) {
+        let editor = cx.new(|cx| Editor::from_markdown(cx, "intro".into(), None));
+
+        editor.update(cx, |editor, cx| {
+            let block = editor.document.visible_blocks()[0].entity.clone();
+            block.update(cx, |block, _cx| {
+                block.selected_range = block.visible_len()..block.visible_len();
+            });
+            editor.on_block_event(
+                block,
+                &BlockEvent::RequestPasteMultiline {
+                    leading: InlineTextTree::plain("intro"),
+                    lines: vec!["> [!NOTE]".to_string(), "> body".to_string()],
+                    trailing: InlineTextTree::plain(String::new()),
+                    split_physical_lines: false,
+                },
+                cx,
+            );
+
+            let roots = editor.document.root_blocks();
+            assert_eq!(roots.len(), 3);
+            assert_eq!(
+                roots[1].read(cx).kind(),
+                BlockKind::Callout(CalloutVariant::Note)
+            );
+            assert_eq!(roots[2].read(cx).kind(), BlockKind::Paragraph);
+            assert_eq!(roots[2].read(cx).display_text(), "");
+        });
+    }
+
+    #[gpui::test]
+    async fn structural_paste_of_footnote_definition_at_document_end_adds_trailing_paragraph(
+        cx: &mut TestAppContext,
+    ) {
+        let editor = cx.new(|cx| Editor::from_markdown(cx, "intro".into(), None));
+
+        editor.update(cx, |editor, cx| {
+            let block = editor.document.visible_blocks()[0].entity.clone();
+            block.update(cx, |block, _cx| {
+                block.selected_range = block.visible_len()..block.visible_len();
+            });
+            editor.on_block_event(
+                block,
+                &BlockEvent::RequestPasteMultiline {
+                    leading: InlineTextTree::plain("intro"),
+                    lines: vec!["[^note]: definition body".to_string()],
+                    trailing: InlineTextTree::plain(String::new()),
+                    split_physical_lines: false,
+                },
+                cx,
+            );
+
+            let roots = editor.document.root_blocks();
+            assert_eq!(roots.len(), 3);
+            assert_eq!(roots[1].read(cx).kind(), BlockKind::FootnoteDefinition);
+            assert_eq!(roots[2].read(cx).kind(), BlockKind::Paragraph);
+            assert_eq!(roots[2].read(cx).display_text(), "");
+        });
+    }
+
+    #[gpui::test]
+    async fn structural_paste_of_standalone_image_at_document_end_adds_trailing_paragraph(
+        cx: &mut TestAppContext,
+    ) {
+        let editor = cx.new(|cx| Editor::from_markdown(cx, "intro".into(), None));
+
+        editor.update(cx, |editor, cx| {
+            let block = editor.document.visible_blocks()[0].entity.clone();
+            block.update(cx, |block, _cx| {
+                block.selected_range = block.visible_len()..block.visible_len();
+            });
+            editor.on_block_event(
+                block,
+                &BlockEvent::RequestPasteMultiline {
+                    leading: InlineTextTree::plain("intro"),
+                    lines: vec!["![alt](pic.png)".to_string()],
+                    trailing: InlineTextTree::plain(String::new()),
+                    split_physical_lines: false,
+                },
+                cx,
+            );
+
+            // A lone image renders as a self-contained widget, so it gets the
+            // same trailing paragraph even though it is a paragraph block.
+            let roots = editor.document.root_blocks();
+            assert_eq!(roots.len(), 3);
+            assert!(roots[1].read(cx).renders_as_standalone_image());
+            assert_eq!(roots[2].read(cx).kind(), BlockKind::Paragraph);
+            assert_eq!(roots[2].read(cx).display_text(), "");
         });
     }
 

--- a/src/editor/selection.rs
+++ b/src/editor/selection.rs
@@ -704,7 +704,16 @@ impl Editor {
         let source = self.current_document_source(cx);
         let mappings = self.source_mapping_by_entity_id(cx);
         let visible = self.document.visible_blocks();
-        let mut chunks = Vec::new();
+
+        // Join blocks with the same spacing the document serializer uses
+        // (collect_root_markdown_lines): a blank line between blocks, but tight
+        // list items stay on consecutive lines. A flat single-newline join used
+        // to silently fuse separate paragraphs on paste, and once setext pairs
+        // are recognized it could even fabricate a heading from two paragraphs.
+        let mut result = String::new();
+        let mut wrote_chunk = false;
+        let mut pending_empty = 0usize;
+        let mut previous_was_list_item = false;
 
         for index in selection.start_index..=selection.end_index {
             let entity = visible.get(index)?.entity.clone();
@@ -731,7 +740,26 @@ impl Editor {
             if range.is_empty() && !include_atomic {
                 continue;
             }
-            chunks.push(self.markdown_chunk_for_block(
+
+            // Empty paragraphs are blank-line separators, not content: defer
+            // them so the gap between real blocks is reproduced as a blank line
+            // rather than collapsed. Atomic content (tables, separators, images)
+            // is len 0 too but is not an empty paragraph, so it still serializes.
+            if (full_block || include_atomic) && Editor::is_empty_root_paragraph(block) {
+                pending_empty += 1;
+                continue;
+            }
+
+            let current_is_list_item = block.kind().is_list_item();
+            if wrote_chunk {
+                let separator_lines = if previous_was_list_item && current_is_list_item {
+                    pending_empty
+                } else {
+                    pending_empty + 1
+                };
+                result.push_str(&"\n".repeat(separator_lines + 1));
+            }
+            result.push_str(&self.markdown_chunk_for_block(
                 &entity,
                 range,
                 full_block || include_atomic,
@@ -739,9 +767,12 @@ impl Editor {
                 &mappings,
                 cx,
             ));
+            wrote_chunk = true;
+            pending_empty = 0;
+            previous_was_list_item = current_is_list_item;
         }
 
-        Some(chunks.join("\n"))
+        Some(result)
     }
 
     fn markdown_chunk_for_block(
@@ -1013,7 +1044,7 @@ mod tests {
 
             assert_eq!(
                 editor.cross_block_selected_markdown(cx).as_deref(),
-                Some("alpha **bold**\n- item\n![alt](image.png)")
+                Some("alpha **bold**\n\n- item\n\n![alt](image.png)")
             );
             for visible in visible {
                 let block = visible.entity.read(cx);
@@ -1038,7 +1069,7 @@ mod tests {
             set_selection(editor, 0, 2, 2, 2, cx);
             assert_eq!(
                 editor.cross_block_selected_markdown(cx).as_deref(),
-                Some("pha\nbeta\nga")
+                Some("pha\n\nbeta\n\nga")
             );
         });
         redraw(cx);
@@ -1050,7 +1081,7 @@ mod tests {
             cx.read_from_clipboard()
                 .and_then(|item| item.text())
                 .as_deref(),
-            Some("pha\nbeta\nga")
+            Some("pha\n\nbeta\n\nga")
         );
         assert_eq!(
             editor.read_with(cx, |editor, cx| editor.document.markdown_text(cx)),
@@ -1067,7 +1098,7 @@ mod tests {
         editor.read_with(cx, |editor, cx| {
             assert_eq!(
                 editor.cross_block_selected_markdown(cx).as_deref(),
-                Some("pha\nbeta\nga")
+                Some("pha\n\nbeta\n\nga")
             );
         });
         cx.quit();

--- a/src/editor/table_edit.rs
+++ b/src/editor/table_edit.rs
@@ -23,7 +23,7 @@ impl Editor {
                     .alignments
                     .get(column)
                     .copied()
-                    .unwrap_or(TableColumnAlignment::Left);
+                    .unwrap_or(TableColumnAlignment::Default);
                 let position = TableCellPosition { row: 0, column };
                 let cell = Self::new_table_cell_block(cx, title, position, alignment);
                 self.table_cells.insert(
@@ -51,7 +51,7 @@ impl Editor {
                             .alignments
                             .get(column)
                             .copied()
-                            .unwrap_or(TableColumnAlignment::Left);
+                            .unwrap_or(TableColumnAlignment::Default);
                         let position = TableCellPosition {
                             row: body_row_index + 1,
                             column,
@@ -156,7 +156,7 @@ impl Editor {
             .alignments
             .last()
             .copied()
-            .unwrap_or(TableColumnAlignment::Left);
+            .unwrap_or(TableColumnAlignment::Default);
         table.append_column(alignment);
 
         table_block.update(cx, move |block, _cx| {
@@ -427,7 +427,7 @@ impl Editor {
         let Some(mut table) = table_block.read(cx).record.table.clone() else {
             return;
         };
-        if table.rows.len() <= 1 || row_index >= table.rows.len() {
+        if row_index >= table.rows.len() {
             return;
         }
         let started_local_capture = if self.pending_undo_capture.is_none() {
@@ -437,23 +437,35 @@ impl Editor {
             false
         };
         table.remove_body_row(row_index);
-        let focus_row = row_index.min(table.rows.len().saturating_sub(1));
+        let remaining_body_rows = table.rows.len();
         table_block.update(cx, move |block, _cx| {
             block.record.table = Some(table.clone());
         });
         self.rebuild_table_runtimes(cx);
         // Row selections are addressed by visual index, where the first body row
-        // is `1` (the header is `0`).
-        let selection = TableAxisSelection {
-            table_block_id: table_block.entity_id(),
-            kind: TableAxisKind::Row,
-            index: focus_row + 1,
+        // is `1` (the header is `0`). With no body rows left, fall back to the
+        // header so focus lands on a cell that still exists.
+        let focus_visual_row = if remaining_body_rows == 0 {
+            0
+        } else {
+            row_index.min(remaining_body_rows - 1) + 1
         };
-        self.set_table_axis_selection(Some(selection), cx);
+        if remaining_body_rows == 0 {
+            self.clear_table_axis_selection(cx);
+        } else {
+            self.set_table_axis_selection(
+                Some(TableAxisSelection {
+                    table_block_id: table_block.entity_id(),
+                    kind: TableAxisKind::Row,
+                    index: focus_visual_row,
+                }),
+                cx,
+            );
+        }
         self.focus_table_cell_position(
             table_block,
             TableCellPosition {
-                row: focus_row + 1,
+                row: focus_visual_row,
                 column: 0,
             },
             cx,
@@ -540,6 +552,47 @@ impl Editor {
             },
             cx,
         );
+        self.mark_dirty(cx);
+        self.request_active_block_scroll_into_view(cx);
+        if started_local_capture {
+            self.finalize_pending_undo_capture(cx);
+        }
+        cx.notify();
+    }
+
+    /// Removes the table block entirely, leaving an empty paragraph in its place
+    /// so the caret has somewhere to land. Used when deleting the last remaining
+    /// row or column, which empties the table.
+    pub(super) fn remove_table_block(
+        &mut self,
+        table_block: &Entity<Block>,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(location) = self.document.find_block_location(table_block.entity_id()) else {
+            return;
+        };
+        let started_local_capture = if self.pending_undo_capture.is_none() {
+            self.prepare_undo_capture(UndoCaptureKind::NonCoalescible, cx);
+            true
+        } else {
+            false
+        };
+        // Insert the replacement paragraph after the table first, then remove the
+        // table, so the document is never momentarily empty.
+        let paragraph = Self::new_block(cx, BlockRecord::paragraph(String::new()));
+        self.document.insert_blocks_at(
+            location.parent.clone(),
+            location.index + 1,
+            vec![paragraph.clone()],
+            cx,
+        );
+        let table_id = table_block.entity_id();
+        self.document.with_structure_mutation(cx, |document, cx| {
+            let _ = document.remove_block_by_id_raw(table_id, cx);
+        });
+        self.rebuild_table_runtimes(cx);
+        self.clear_table_axis_selection(cx);
+        self.focus_block(paragraph.entity_id());
         self.mark_dirty(cx);
         self.request_active_block_scroll_into_view(cx);
         if started_local_capture {

--- a/src/editor/tests.rs
+++ b/src/editor/tests.rs
@@ -902,7 +902,7 @@ async fn append_column_updates_table_and_focuses_new_header_cell(cx: &mut TestAp
         assert_eq!(
             record.alignments,
             vec![
-                TableColumnAlignment::Left,
+                TableColumnAlignment::Default,
                 TableColumnAlignment::Right,
                 TableColumnAlignment::Right,
             ]
@@ -963,7 +963,7 @@ async fn setting_column_alignment_updates_record_and_selection(cx: &mut TestAppC
         let record = table.read(cx).record.table.as_ref().expect("table record");
         assert_eq!(
             record.alignments,
-            vec![TableColumnAlignment::Left, TableColumnAlignment::Right]
+            vec![TableColumnAlignment::Default, TableColumnAlignment::Right]
         );
         assert_eq!(
             editor.table_axis_selection,
@@ -1181,6 +1181,70 @@ async fn deleting_table_header_promotes_next_row(cx: &mut TestAppContext) {
             .as_ref()
             .expect("rebuilt runtime");
         assert_eq!(editor.pending_focus, Some(runtime.header[0].entity_id()));
+    });
+}
+
+#[gpui::test]
+async fn deleting_last_body_row_leaves_header_only_table(cx: &mut TestAppContext) {
+    let markdown = ["| A | B |", "| --- | --- |", "| 1 | 2 |"].join("\n");
+    let editor = cx.new(|cx| Editor::from_markdown(cx, markdown, None));
+
+    editor.update(cx, |editor, cx| {
+        let table = editor.document.first_root().expect("table root").clone();
+        // Deleting the only body row used to be blocked; now it leaves a
+        // header-only table behind.
+        editor.delete_table_row(&table, 0, cx);
+
+        let record = table.read(cx).record.table.as_ref().expect("table record");
+        assert!(record.rows.is_empty());
+        assert_eq!(record.header[0].serialize_markdown(), "A");
+        assert_eq!(editor.document.root_count(), 1);
+        assert_eq!(table.read(cx).kind(), BlockKind::Table);
+    });
+}
+
+#[gpui::test]
+async fn removing_table_block_replaces_it_with_empty_paragraph(cx: &mut TestAppContext) {
+    let markdown = [
+        "intro",
+        "",
+        "| A | B |",
+        "| --- | --- |",
+        "| 1 | 2 |",
+        "",
+        "outro",
+    ]
+    .join("\n");
+    let editor = cx.new(|cx| Editor::from_markdown(cx, markdown, None));
+
+    editor.update(cx, |editor, cx| {
+        let table = editor.document.root_blocks()[1].clone();
+        assert_eq!(table.read(cx).kind(), BlockKind::Table);
+        editor.remove_table_block(&table, cx);
+
+        let roots = editor.document.root_blocks();
+        assert_eq!(roots.len(), 3);
+        assert_eq!(roots[0].read(cx).display_text(), "intro");
+        assert_eq!(roots[1].read(cx).kind(), BlockKind::Paragraph);
+        assert_eq!(roots[1].read(cx).display_text(), "");
+        assert_eq!(roots[2].read(cx).display_text(), "outro");
+        assert_eq!(editor.pending_focus, Some(roots[1].entity_id()));
+    });
+}
+
+#[gpui::test]
+async fn removing_the_only_table_leaves_one_empty_paragraph(cx: &mut TestAppContext) {
+    let markdown = ["| A | B |", "| --- | --- |", "| 1 | 2 |"].join("\n");
+    let editor = cx.new(|cx| Editor::from_markdown(cx, markdown, None));
+
+    editor.update(cx, |editor, cx| {
+        let table = editor.document.first_root().expect("table root").clone();
+        editor.remove_table_block(&table, cx);
+
+        let roots = editor.document.root_blocks();
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].read(cx).kind(), BlockKind::Paragraph);
+        assert_eq!(roots[0].read(cx).display_text(), "");
     });
 }
 

--- a/src/editor/tree.rs
+++ b/src/editor/tree.rs
@@ -108,6 +108,17 @@ impl DocumentTree {
         self.snapshot.location_by_entity.get(&entity_id).cloned()
     }
 
+    /// Returns the sibling immediately before `entity_id` within the same
+    /// parent, if any.
+    pub(super) fn previous_sibling(&self, entity_id: EntityId, cx: &App) -> Option<Entity<Block>> {
+        let location = self.find_block_location(entity_id)?;
+        let prev_index = location.index.checked_sub(1)?;
+        match &location.parent {
+            Some(parent) => parent.read(cx).children.get(prev_index).cloned(),
+            None => self.roots.get(prev_index).cloned(),
+        }
+    }
+
     pub(super) fn last_visible_descendant(&self, entity_id: EntityId) -> Option<Entity<Block>> {
         let descendant_id = self
             .snapshot


### PR DESCRIPTION
This PR includes fixes for #81, as well as some other fixes and improvements made along the way, and brings live Rendered editing closer to what the document importer already supports.

All changes are confined to the existing parser/runtime model. No new dependencies.

Unit tests have been added for all of the following.

## Fixes and improvements

- Setext headings (`=====`/`-----`) are now recognized on paste and form live in Rendered mode as you type.
- Native tables now form live in Rendered mode as you type.
- Pipeless GFM tables (no outer pipes) are now recognized whether imported, pasted, or typed in rendered mode.
- Ragged tables (missing cells) are now accepted.
- An explicit `:---` left-alignment marker survives a round-trip (was formerly auto-adjusted which removed user's input), while the Align Left menu still uses the clean `---`.
- Cross-block copies now properly round-trip instead of fusing.
- The last remaining row or column of a table can now be deleted, which removes the table entirely.
- Scrolling no longer stops when the pointer is over a table's edge handles.
- In Rendered mode, all structural blocks (tables, code blocks, etc) placed at the end of the document now get a trailing block so the caret can move past them without extra effort. You can simply press Down or click on the block below. Previously you were required to either know the Ctrl+Enter shortcut or swap to Source mode to escape them. This fix was applied to tables recently; now it's applied to all structural markdown that otherwise has this 'locked-in' effect. This fix is omitted where you can already simply press Enter to escape the structure, and of course it omits Source mode since you can always press Enter to form a new line there.
- History capture is managed at the editor level for these operations, making them reversible as single steps.

## Details

#### Setext heading formation (typing)
Added `try_form_setext_heading_on_newline()` to detect when Enter is pressed on a paragraph containing only a setext underline. If a matching paragraph precedes it at the root level, the two collapse into a heading. `-----` with no target becomes a separator; `=====` with no target stays plain text (CommonMark).

#### Pipe and pipeless table formation and extension (typing)
Added `try_form_or_extend_table_on_newline()`. A delimiter row typed under a header paragraph forms a native table, and a body row typed below an existing table is absorbed via `extend_table_with_typed_row()`. The gate accepts pipeless rows too. Table extension syncs any in-progress cell edits before mutating the record to avoid data loss.

#### Pipeless table recognition on paste
The rendered-paste classifier now detects a pipeless header-plus-delimiter region up front and routes the whole paste to the block builder.

#### Trailing paragraph after structural blocks
Added `ensure_trailing_paragraph_after_structural()` to insert an empty block/paragraph after atomic structures (tables, code blocks, math, separators, quotes, callouts, footnote definitions, standalone images) when they end the document.

#### Deleting a table's last row or column
Previously the Delete Row and Delete Column menu items were disabled if it was the last remaining. They are now always enabled; deleting the last column, or the header of a header-only table, removes the whole block via `remove_table_block()` (leaving an empty block in its place). The body-row guard was relaxed so a table can be reduced to header-only first, so each Delete Row removes exactly one visual row until the table is gone. This was chosen rather than removing the whole table on the last body row, so each Delete Row affects exactly one visual row. A header-only table was already a valid state reachable through header promotion. You can then delete the last remaining (header) row to delete the table entirely.

#### Scrolling past table edge handles
The table axis bands and append buttons used `occlude()` (`HitboxBehavior::BlockMouse`), which also swallows scroll-wheel events, so scrolling halted when the cursor collided with the top edge. They now use `block_mouse_except_scroll()`, which still captures clicks and hover for axis selection while letting scroll move past. `block_mouse_except_scroll()` was preferred over dropping `occlude()` entirely, since the click-to-select-axis interaction would fall through to the cells.

#### Table alignment preservation
The `TableColumnAlignment` enum now distinguishes unmarked columns (`Default`) from explicitly left-aligned columns (`Left`), preventing silent rewrites of alignment markers on serialize. The Align Left menu maps to `Default` so it still emits the unmarked `---`; the explicit `:---` form is reserved for round-tripping source that already used a colon. Otherwise Velotype would be needlessly auto-editing the user's input.

#### Ragged and pipeless parsing
Body rows are normalized to the header width (short rows padded, long rows truncated) per GFM rather than invalidating the whole table. Added `collect_pipeless_table_region()` and `parse_table_body_row()`, and made `split_table_cells()` treat outer pipes as optional so `Cell1 | Cell2` parses like `| Cell1 | Cell2 |`.

#### Cross-block copy line breaks
Updated `collect_root_markdown_lines()` in selection.rs to separate blocks with blank lines (except tight list items), so copied blocks round-trip instead of fusing on paste.

#### Block kind helpers
`is_atomic_structural()` identifies blocks that render as self-contained widgets needing a trailing block/paragraph. `renders_as_standalone_image()` detects lone images.