### PR TITLE
Fix Open Recent File submenu intermittently collapsing on Windows/Linux

### DIFF
--- a/src/editor/events.rs
+++ b/src/editor/events.rs
@@ -972,6 +972,15 @@ impl Editor {
         self.set_menu_submenu_panel_hovered(*hovered, cx);
     }
 
+    pub(crate) fn on_menu_submenu_bridge_hover(
+        &mut self,
+        hovered: &bool,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.set_menu_submenu_bridge_hovered(*hovered, cx);
+    }
+
     pub(crate) fn on_editor_mouse_down(
         &mut self,
         _event: &MouseDownEvent,

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -108,6 +108,11 @@ pub struct Editor {
     menu_bar_hovered: bool,
     menu_panel_hovered: bool,
     menu_submenu_panel_hovered: bool,
+    /// Hover state for the invisible bridge spanning the gap between the menu
+    /// panel and an open submenu. Tracked separately from
+    /// `menu_submenu_panel_hovered` so the handoff between the two regions
+    /// cannot clobber a single shared flag and tear the menu down.
+    menu_submenu_bridge_hovered: bool,
     menu_close_task: Option<Task<()>>,
     view_mode_toggle_hovered: bool,
     scrollbar_hovered: bool,
@@ -298,6 +303,7 @@ impl Editor {
             menu_bar_hovered: false,
             menu_panel_hovered: false,
             menu_submenu_panel_hovered: false,
+            menu_submenu_bridge_hovered: false,
             menu_close_task: None,
             view_mode_toggle_hovered: false,
             scrollbar_hovered: false,

--- a/src/editor/render.rs
+++ b/src/editor/render.rs
@@ -838,7 +838,7 @@ impl Editor {
                             .w(px(geometry.width))
                             .h(px(geometry.height))
                             .bg(hsla(0.0, 0.0, 0.0, 0.0))
-                            .on_hover(cx.listener(Self::on_menu_submenu_panel_hover))
+                            .on_hover(cx.listener(Self::on_menu_submenu_bridge_hover))
                             .into_any_element(),
                     )
                 }

--- a/src/editor/tests.rs
+++ b/src/editor/tests.rs
@@ -819,6 +819,43 @@ async fn submenu_panel_hover_keeps_in_window_menu_open(cx: &mut TestAppContext) 
     });
 }
 
+// The gap bridge and the submenu panel overlap, so moving the cursor from the
+// bridge onto the submenu emits `bridge: false` and `panel: true` in the same
+// gesture. With both regions sharing one hover flag the stale `bridge: false`
+// could win and tear the menu down, which made reaching the recent-files list
+// fail intermittently. Track the two regions independently so the handoff
+// always keeps the menu open, regardless of event order.
+#[gpui::test]
+async fn submenu_survives_bridge_to_panel_hover_handoff(cx: &mut TestAppContext) {
+    let editor = cx.new(|cx| Editor::from_markdown(cx, "alpha".to_string(), None));
+
+    editor.update(cx, |editor, cx| {
+        editor.open_menu_bar(0, cx);
+        editor.open_menu_submenu(3, cx);
+
+        // Crossing the gap: only the bridge is hovered.
+        editor.set_menu_panel_hovered(false, cx);
+        editor.set_menu_bar_hovered(false, cx);
+        editor.set_menu_submenu_bridge_hovered(true, cx);
+        assert!(editor.menu_close_task.is_none());
+
+        // Handoff into the submenu panel. The bridge reporting `false` after
+        // the panel is already hovered must not schedule a close.
+        editor.set_menu_submenu_panel_hovered(true, cx);
+        editor.set_menu_submenu_bridge_hovered(false, cx);
+
+        assert_eq!(editor.menu_bar_open, Some(0));
+        assert_eq!(editor.menu_submenu_open, Some(3));
+        assert!(editor.menu_submenu_panel_hovered);
+        assert!(
+            editor.menu_close_task.is_none(),
+            "menu must stay open across the bridge-to-panel handoff"
+        );
+
+        editor.close_menu_bar(cx);
+    });
+}
+
 #[gpui::test]
 async fn starting_and_ending_scrollbar_drag_updates_editor_state(cx: &mut TestAppContext) {
     let editor = cx.new(|cx| Editor::from_markdown(cx, "alpha".to_string(), None));

--- a/src/editor/window_state.rs
+++ b/src/editor/window_state.rs
@@ -291,6 +291,7 @@ impl Editor {
         self.menu_bar_open = None;
         self.menu_submenu_open = None;
         self.menu_submenu_panel_hovered = false;
+        self.menu_submenu_bridge_hovered = false;
         self.info_dialog = Some(kind);
         cx.notify();
     }
@@ -307,6 +308,7 @@ impl Editor {
             self.menu_bar_open = Some(index);
             self.menu_submenu_open = None;
             self.menu_submenu_panel_hovered = false;
+            self.menu_submenu_bridge_hovered = false;
             cx.notify();
         }
     }
@@ -321,8 +323,9 @@ impl Editor {
 
     pub(crate) fn close_menu_submenu(&mut self, cx: &mut Context<Self>) {
         let had_open_submenu = self.menu_submenu_open.take().is_some();
-        let had_submenu_hover = self.menu_submenu_panel_hovered;
+        let had_submenu_hover = self.menu_submenu_panel_hovered || self.menu_submenu_bridge_hovered;
         self.menu_submenu_panel_hovered = false;
+        self.menu_submenu_bridge_hovered = false;
         if had_open_submenu || had_submenu_hover {
             cx.notify();
         }
@@ -344,6 +347,7 @@ impl Editor {
                     if !editor.menu_bar_hovered
                         && !editor.menu_panel_hovered
                         && !editor.menu_submenu_panel_hovered
+                        && !editor.menu_submenu_bridge_hovered
                     {
                         editor.close_menu_bar(cx);
                     }
@@ -356,7 +360,10 @@ impl Editor {
         self.menu_bar_hovered = hovered;
         if hovered {
             self.menu_close_task = None;
-        } else if !self.menu_panel_hovered && !self.menu_submenu_panel_hovered {
+        } else if !self.menu_panel_hovered
+            && !self.menu_submenu_panel_hovered
+            && !self.menu_submenu_bridge_hovered
+        {
             self.schedule_menu_bar_close(cx);
         }
     }
@@ -365,7 +372,10 @@ impl Editor {
         self.menu_panel_hovered = hovered;
         if hovered {
             self.menu_close_task = None;
-        } else if !self.menu_bar_hovered && !self.menu_submenu_panel_hovered {
+        } else if !self.menu_bar_hovered
+            && !self.menu_submenu_panel_hovered
+            && !self.menu_submenu_bridge_hovered
+        {
             self.schedule_menu_bar_close(cx);
         }
     }
@@ -374,7 +384,31 @@ impl Editor {
         self.menu_submenu_panel_hovered = hovered;
         if hovered {
             self.menu_close_task = None;
-        } else if !self.menu_bar_hovered && !self.menu_panel_hovered {
+        } else if !self.menu_bar_hovered
+            && !self.menu_panel_hovered
+            && !self.menu_submenu_bridge_hovered
+        {
+            self.schedule_menu_bar_close(cx);
+        }
+    }
+
+    /// Hover handler for the invisible gap bridge. The bridge and the submenu
+    /// panel overlap, so the cursor crossing between them fires a `false` for
+    /// one region and a `true` for the other in the same gesture. Keeping their
+    /// hover state in separate flags lets either one hold the menu open
+    /// regardless of the order those events arrive.
+    pub(crate) fn set_menu_submenu_bridge_hovered(
+        &mut self,
+        hovered: bool,
+        cx: &mut Context<Self>,
+    ) {
+        self.menu_submenu_bridge_hovered = hovered;
+        if hovered {
+            self.menu_close_task = None;
+        } else if !self.menu_bar_hovered
+            && !self.menu_panel_hovered
+            && !self.menu_submenu_panel_hovered
+        {
             self.schedule_menu_bar_close(cx);
         }
     }
@@ -422,12 +456,15 @@ impl Editor {
     pub(crate) fn close_menu_bar(&mut self, cx: &mut Context<Self>) {
         let had_open_menu = self.menu_bar_open.take().is_some();
         let had_open_submenu = self.menu_submenu_open.take().is_some();
-        let had_hover_state =
-            self.menu_bar_hovered || self.menu_panel_hovered || self.menu_submenu_panel_hovered;
+        let had_hover_state = self.menu_bar_hovered
+            || self.menu_panel_hovered
+            || self.menu_submenu_panel_hovered
+            || self.menu_submenu_bridge_hovered;
         let had_pending_close = self.menu_close_task.take().is_some();
         self.menu_bar_hovered = false;
         self.menu_panel_hovered = false;
         self.menu_submenu_panel_hovered = false;
+        self.menu_submenu_bridge_hovered = false;
         if had_open_menu || had_open_submenu || had_hover_state || had_pending_close {
             cx.notify();
         }


### PR DESCRIPTION
This PR fixes issue #88.

## Bug

Fixes a Windows/Linux bug where **File > Open Recent File** intermittently collapses the whole dropdown the moment you move toward the listed recent files. This bug is not present on Mac.

## Cause

On Windows and Linux the app draws its own in-window menu bar (Mac uses the native menu). When a submenu is open, the menu panel renders an invisible "bridge" element across the small gap to the submenu so the cursor can travel between them without falling into a dead zone. That bridge's geometry overlaps the submenu panel, and both regions were wired to the same hover handler writing the same `menu_submenu_panel_hovered` flag.

Crossing from the bridge onto the submenu fires two hover events in the same gesture: `bridge: hovered = false` and `submenu panel: hovered = true`. Because they wrote the same boolean, the surviving value depended on the (random-ish) order GPUI dispatched them:

- `panel: true` then `bridge: false` - the menu-close timer fires - the entire dropdown closes a split-second later.
- `bridge: false` then `panel: true` - the menu stays open.

That order isn't stable, which is exactly why it "worked sometimes" with no discernible pattern.

## Fix

Give the bridge its **own** hover flag (`menu_submenu_bridge_hovered`) instead of sharing `menu_submenu_panel_hovered`. The menu now stays open if _either_ region is hovered, so the bridge-to-panel handoff can no longer clobber a single flag, regardless of event order.

This extends the existing menu hover/close model.

## Test

New unit test `submenu_survives_bridge_to_panel_hover_handoff` reproduces the handoff.