### PR TITLE
feat: add status bar and animated Switch

### DIFF
--- a/assets/custom-language.example.jsonc
+++ b/assets/custom-language.example.jsonc
@@ -186,6 +186,16 @@
     "image_placeholder": "",
     "image_loading_without_alt": "",
     "image_loading_with_alt_template": "",
-    "code_language_placeholder": ""
+    "code_language_placeholder": "",
+    "status_bar_files": "",
+    "status_bar_mode_source": "",
+    "status_bar_mode_rendered": "",
+    "status_bar_word_count_suffix": "",
+    "preferences_nav_status_bar": "",
+    "preferences_status_bar_enabled": "",
+    "preferences_status_bar_show_word_count": "",
+    "preferences_status_bar_show_cursor_position": "",
+    "preferences_status_bar_show_sidebar_toggle": "",
+    "preferences_status_bar_show_mode_switch": "",
   }
 }

--- a/assets/custom-theme.example.jsonc
+++ b/assets/custom-theme.example.jsonc
@@ -194,7 +194,15 @@
       // Hover background of destructive dialog buttons.
       "dialog_danger_button_hover": null,
       // Text color of destructive dialog buttons.
-      "dialog_danger_button_text": null
+      "dialog_danger_button_text": null,
+      // Background of the editor status bar.
+      "status_bar_background": null,
+      // Primary text color in the status bar.
+      "status_bar_text": null,
+      // Secondary text color in the status bar.
+      "status_bar_text_dim": null,
+      // Hover background for clickable status bar item.
+      "status_bar_button_hover": null
     },
     // Dimensions are logical pixels unless a comment explicitly says ratio.
     // Set null to inherit base_theme_id and avoid storing the field after import.
@@ -418,7 +426,15 @@
       // Border width of the view-mode toggle.
       "view_mode_toggle_border_width": null,
       // Text size of the view-mode toggle.
-      "view_mode_toggle_text_size": null
+      "view_mode_toggle_text_size": null,
+      // Height of the status bar.
+      "status_bar_height": null,
+      // Horizontal padding inside the status bar.
+      "status_bar_padding_x": null,
+      // Gap between items in the status bar.
+      "status_bar_item_gap": null,
+      // Font size for status bar text.
+      "status_bar_text_size": null
     },
     // Typography values use logical pixels for sizes and a ratio for line height.
     // Weight values allow thin, light, normal, medium, semibold, bold, extrabold, or black.

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -2,10 +2,10 @@
 
 mod actions;
 mod block;
-pub(crate) mod switch;
 pub(crate) mod latex;
 pub(crate) mod markdown;
 pub(crate) mod mermaid;
+pub(crate) mod switch;
 
 pub use crate::editor::Editor;
 #[allow(unused_imports)]

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -2,6 +2,7 @@
 
 mod actions;
 mod block;
+pub(crate) mod switch;
 pub(crate) mod latex;
 pub(crate) mod markdown;
 pub(crate) mod mermaid;

--- a/src/components/switch.rs
+++ b/src/components/switch.rs
@@ -1,0 +1,91 @@
+//! A pill-shaped toggle switch component.
+
+use gpui::*;
+
+use crate::theme::ThemeManager;
+
+/// A toggle switch that can be checked or unchecked.
+#[derive(IntoElement)]
+pub(crate) struct Switch {
+    id: ElementId,
+    checked: bool,
+    disabled: bool,
+    on_click: Option<Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
+}
+
+impl Switch {
+    pub fn new(id: impl Into<ElementId>) -> Self {
+        Self {
+            id: id.into(),
+            checked: false,
+            disabled: false,
+            on_click: None,
+        }
+    }
+
+    /// Set the checked state.
+    pub fn checked(mut self, checked: bool) -> Self {
+        self.checked = checked;
+        self
+    }
+
+    /// Set the click handler.
+    pub fn on_click(
+        mut self,
+        handler: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    ) -> Self {
+        self.on_click = Some(Box::new(handler));
+        self
+    }
+}
+
+impl RenderOnce for Switch {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        use gpui::prelude::FluentBuilder as _;
+
+        let theme = cx.global::<ThemeManager>().current().clone();
+        let c = &theme.colors;
+
+        let checked = self.checked;
+        let disabled = self.disabled;
+
+        let track_color = if disabled {
+            c.dialog_secondary_button_bg
+        } else if checked {
+            c.dialog_primary_button_bg
+        } else {
+            c.dialog_secondary_button_bg
+        };
+        let thumb_color = if disabled {
+            c.dialog_secondary_button_text
+        } else if checked {
+            c.dialog_primary_button_text
+        } else {
+            c.dialog_secondary_button_text
+        };
+        // Track: 36×20. px(2) leaves 32px of inner width.
+        // Thumb: 16×16. When unchecked: ml=0 (2px from left edge).
+        // When checked: ml=16 (2px from right edge).
+        let thumb_margin: f32 = if checked { 16.0 } else { 0.0 };
+
+        div()
+            .id(self.id)
+            .w(px(36.0))
+            .h(px(20.0))
+            .px(px(2.0))
+            .flex()
+            .items_center()
+            .rounded(px(10.0))
+            .bg(track_color)
+            .when(!disabled, |this| this.cursor_pointer())
+            .child(
+                div()
+                    .w(px(16.0))
+                    .h(px(16.0))
+                    .ml(px(thumb_margin))
+                    .rounded(px(8.0))
+                    .bg(thumb_color),
+            )
+            .when_some(self.on_click, |this, on_click| this.on_click(on_click))
+    }
+}

--- a/src/components/switch.rs
+++ b/src/components/switch.rs
@@ -1,6 +1,8 @@
-//! A pill-shaped toggle switch component.
+//! A pill-shaped toggle switch component with slide animation.
 
-use gpui::*;
+use std::time::Duration;
+
+use gpui::{prelude::FluentBuilder, *};
 
 use crate::theme::ThemeManager;
 
@@ -40,9 +42,7 @@ impl Switch {
 }
 
 impl RenderOnce for Switch {
-    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
-        use gpui::prelude::FluentBuilder as _;
-
+    fn render(self, window: &mut Window, cx: &mut App) -> impl IntoElement {
         let theme = cx.global::<ThemeManager>().current().clone();
         let c = &theme.colors;
 
@@ -63,10 +63,50 @@ impl RenderOnce for Switch {
         } else {
             c.dialog_secondary_button_text
         };
-        // Track: 36×20. px(2) leaves 32px of inner width.
-        // Thumb: 16×16. When unchecked: ml=0 (2px from left edge).
-        // When checked: ml=16 (2px from right edge).
-        let thumb_margin: f32 = if checked { 16.0 } else { 0.0 };
+
+        // Keep the visual position across renders so we can detect changes.
+        let toggle_state = window.use_keyed_state::<bool>(self.id.clone(), cx, |_, _| checked);
+        let prev_checked = *toggle_state.read(cx);
+        let target: f32 = if checked { 16.0 } else { 0.0 };
+        let origin: f32 = if prev_checked { 16.0 } else { 0.0 };
+        let needs_animation = prev_checked != checked;
+        let duration = Duration::from_secs_f64(0.18);
+
+        if needs_animation {
+            cx.spawn({
+                let toggle_state = toggle_state.clone();
+                async move |cx| {
+                    cx.background_executor().timer(duration).await;
+                    _ = toggle_state.update(cx, |state, _| *state = checked);
+                }
+            })
+            .detach();
+        }
+
+        let thumb = div()
+            .w(px(16.0))
+            .h(px(16.0))
+            .rounded(px(8.0))
+            .bg(thumb_color)
+            .map(|mut this| {
+                if needs_animation {
+                    this.with_animation(
+                        ElementId::NamedInteger("switch-move".into(), checked as u64),
+                        Animation::new(duration),
+                        move |mut this, delta| {
+                            let margin = origin + (target - origin) * delta;
+                            this.style().margin.left =
+                                Some(Length::Definite(DefiniteLength::from(px(margin))));
+                            this
+                        },
+                    )
+                    .into_any_element()
+                } else {
+                    this.style().margin.left =
+                        Some(Length::Definite(DefiniteLength::from(px(target))));
+                    this.into_any_element()
+                }
+            });
 
         div()
             .id(self.id)
@@ -78,14 +118,7 @@ impl RenderOnce for Switch {
             .rounded(px(10.0))
             .bg(track_color)
             .when(!disabled, |this| this.cursor_pointer())
-            .child(
-                div()
-                    .w(px(16.0))
-                    .h(px(16.0))
-                    .ml(px(thumb_margin))
-                    .rounded(px(8.0))
-                    .bg(thumb_color),
-            )
+            .child(thumb)
             .when_some(self.on_click, |this, on_click| this.on_click(on_click))
     }
 }

--- a/src/config/preferences.rs
+++ b/src/config/preferences.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 use anyhow::Context as _;
 use gpui::prelude::FluentBuilder;
 use gpui::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use super::{VelotypeConfigDirs, read_recent_files};
 use crate::components::{
@@ -22,6 +22,38 @@ use crate::window_chrome::{
 
 const DEFAULT_THEME_ID: &str = "velotype";
 const DEFAULT_LANGUAGE_ID: &str = "en-US";
+
+/// A user-configurable button shown in the status bar.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct StatusBarButton {
+    pub id: String,
+    pub label: String,
+    pub action_id: String,
+}
+
+/// Status bar visibility and component toggles.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct StatusBarPreferences {
+    pub enabled: bool,
+    pub show_word_count: bool,
+    pub show_cursor_position: bool,
+    pub show_sidebar_toggle: bool,
+    pub show_mode_switch: bool,
+    pub custom_buttons: Vec<StatusBarButton>,
+}
+
+impl Default for StatusBarPreferences {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            show_word_count: true,
+            show_cursor_position: true,
+            show_sidebar_toggle: true,
+            show_mode_switch: true,
+            custom_buttons: Vec::new(),
+        }
+    }
+}
 
 /// Startup document selection stored in `config.toml`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -84,6 +116,7 @@ pub(crate) struct AppPreferences {
     pub(crate) show_table_headers: bool,
     pub(crate) image_paste_behavior: ImagePasteBehavior,
     pub(crate) keybindings: BTreeMap<String, Vec<String>>,
+    pub(crate) status_bar: StatusBarPreferences,
 }
 
 impl Default for AppPreferences {
@@ -95,6 +128,7 @@ impl Default for AppPreferences {
             show_table_headers: true,
             image_paste_behavior: ImagePasteBehavior::None,
             keybindings: BTreeMap::new(),
+            status_bar: StatusBarPreferences::default(),
         }
     }
 }
@@ -141,6 +175,7 @@ struct PreferencesFile {
     language: LanguagePreferencesFile,
     theme: ThemePreferencesFile,
     editor: EditorPreferencesFile,
+    status_bar: StatusBarPreferencesFile,
     keybindings: BTreeMap<String, Vec<String>>,
 }
 
@@ -165,6 +200,30 @@ struct ThemePreferencesFile {
     default_theme_id: String,
 }
 
+#[derive(Serialize)]
+struct StatusBarPreferencesFile {
+    enabled: bool,
+    show_word_count: bool,
+    show_cursor_position: bool,
+    show_sidebar_toggle: bool,
+    show_mode_switch: bool,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    custom_buttons: Vec<StatusBarButton>,
+}
+
+impl From<&StatusBarPreferences> for StatusBarPreferencesFile {
+    fn from(value: &StatusBarPreferences) -> Self {
+        Self {
+            enabled: value.enabled,
+            show_word_count: value.show_word_count,
+            show_cursor_position: value.show_cursor_position,
+            show_sidebar_toggle: value.show_sidebar_toggle,
+            show_mode_switch: value.show_mode_switch,
+            custom_buttons: value.custom_buttons.clone(),
+        }
+    }
+}
+
 impl From<&AppPreferences> for PreferencesFile {
     fn from(value: &AppPreferences) -> Self {
         Self {
@@ -181,6 +240,7 @@ impl From<&AppPreferences> for PreferencesFile {
                 show_table_headers: value.show_table_headers,
                 image_paste_behavior: value.image_paste_behavior.as_str().into(),
             },
+            status_bar: StatusBarPreferencesFile::from(&value.status_bar),
             keybindings: normalize_shortcut_config(&value.keybindings),
         }
     }
@@ -272,6 +332,58 @@ fn app_preferences_from_toml_value(
         .map(ImagePasteBehavior::from_str)
         .unwrap_or(ImagePasteBehavior::None);
 
+    let status_bar = value
+        .get("status_bar")
+        .map(|sb| {
+            let enabled = sb.get("enabled").and_then(|v| v.as_bool()).unwrap_or(true);
+            let show_word_count = sb
+                .get("show_word_count")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            let show_cursor_position = sb
+                .get("show_cursor_position")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            let show_sidebar_toggle = sb
+                .get("show_sidebar_toggle")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            let show_mode_switch = sb
+                .get("show_mode_switch")
+                .and_then(|v| v.as_bool())
+                .unwrap_or(true);
+            let custom_buttons = sb
+                .get("custom_buttons")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|item| {
+                            let id = item.get("id")?.as_str()?.to_string();
+                            let label = item.get("label")?.as_str()?.to_string();
+                            Some(StatusBarButton {
+                                id,
+                                label,
+                                action_id: item
+                                    .get("action_id")
+                                    .and_then(|a| a.as_str())
+                                    .unwrap_or("")
+                                    .to_string(),
+                            })
+                        })
+                        .collect()
+                })
+                .unwrap_or_default();
+            StatusBarPreferences {
+                enabled,
+                show_word_count,
+                show_cursor_position,
+                show_sidebar_toggle,
+                show_mode_switch,
+                custom_buttons,
+            }
+        })
+        .unwrap_or_default();
+
     AppPreferences {
         startup_open,
         default_language_id,
@@ -279,6 +391,7 @@ fn app_preferences_from_toml_value(
         show_table_headers,
         image_paste_behavior,
         keybindings,
+        status_bar,
     }
 }
 
@@ -1606,7 +1719,7 @@ pub(crate) fn open_preferences_window(cx: &mut App) -> WindowHandle<PreferencesW
 #[cfg(test)]
 mod tests {
     use super::{
-        AppPreferences, ImagePasteBehavior, StartupOpenPreference,
+        AppPreferences, ImagePasteBehavior, StartupOpenPreference, StatusBarPreferences,
         load_or_create_app_preferences_with_dirs_and_locales, open_preferences_window_with_state,
         read_app_preferences_with_dirs, save_app_preferences_with_dirs,
         save_preferences_from_window_with_dirs,
@@ -1727,6 +1840,7 @@ mod tests {
             show_table_headers: false,
             image_paste_behavior: ImagePasteBehavior::CopyToAssetsFolder,
             keybindings: BTreeMap::new(),
+            status_bar: StatusBarPreferences::default(),
         };
 
         save_app_preferences_with_dirs(&preferences, &dirs)
@@ -1810,6 +1924,7 @@ mod tests {
             show_table_headers: true,
             image_paste_behavior: ImagePasteBehavior::None,
             keybindings: BTreeMap::new(),
+            status_bar: StatusBarPreferences::default(),
         };
         save_app_preferences_with_dirs(&preferences, &dirs)
             .expect("preferences should save to config.toml");

--- a/src/config/preferences.rs
+++ b/src/config/preferences.rs
@@ -12,7 +12,7 @@ use super::{VelotypeConfigDirs, read_recent_files};
 use crate::components::{
     ShortcutCategory, ShortcutCommand, ShortcutDefinition, install_keybindings,
     normalize_shortcut_config, normalize_shortcut_keys, resolved_shortcut_keys,
-    shortcut_conflict_for, shortcut_definitions,
+    shortcut_conflict_for, shortcut_definitions, switch::Switch,
 };
 use crate::i18n::{I18nManager, language_id_for_locale_preferences};
 use crate::theme::{Theme, ThemeCatalogEntry, ThemeManager};
@@ -133,18 +133,45 @@ impl Default for AppPreferences {
     }
 }
 
+/// Status Bar Settings
+struct StatusBarSettings {
+    status_bar_enabled: bool,
+    status_bar_show_word_count: bool,
+    status_bar_show_cursor_position: bool,
+    status_bar_show_sidebar_toggle: bool,
+    status_bar_show_mode_switch: bool,
+}
+
 /// Runtime-accessible editor settings mirrored from [`AppPreferences`] so the
 /// render path can read them without touching disk. Toggling persists the new
 /// value back to the preferences file.
 pub struct EditorSettings {
     show_table_headers: bool,
+    status_bar_settings: StatusBarSettings,
 }
 
 impl Global for EditorSettings {}
 
 impl EditorSettings {
     pub fn init(cx: &mut App, show_table_headers: bool) {
-        cx.set_global(Self { show_table_headers });
+        let status_bar = read_app_preferences()
+            .ok()
+            .map(|p| p.status_bar)
+            .unwrap_or_default();
+        Self::set_global(cx, show_table_headers, &status_bar);
+    }
+
+    fn set_global(cx: &mut App, show_table_headers: bool, status_bar: &StatusBarPreferences) {
+        cx.set_global(Self {
+            show_table_headers,
+            status_bar_settings: StatusBarSettings {
+                status_bar_enabled: status_bar.enabled,
+                status_bar_show_word_count: status_bar.show_word_count,
+                status_bar_show_cursor_position: status_bar.show_cursor_position,
+                status_bar_show_sidebar_toggle: status_bar.show_sidebar_toggle,
+                status_bar_show_mode_switch: status_bar.show_mode_switch,
+            }
+        });
     }
 
     /// Whether table top rows are styled as headers. Defaults to `true` when
@@ -156,7 +183,18 @@ impl EditorSettings {
     }
 
     pub fn set_show_table_headers(cx: &mut App, show_table_headers: bool) {
-        cx.set_global(Self { show_table_headers });
+        let status_bar = cx
+            .try_global::<Self>()
+            .map(|s| StatusBarPreferences {
+                enabled: s.status_bar_settings.status_bar_enabled,
+                show_word_count: s.status_bar_settings.status_bar_show_word_count,
+                show_cursor_position: s.status_bar_settings.status_bar_show_cursor_position,
+                show_sidebar_toggle: s.status_bar_settings.status_bar_show_sidebar_toggle,
+                show_mode_switch: s.status_bar_settings.status_bar_show_mode_switch,
+                custom_buttons: Vec::new(),
+            })
+            .unwrap_or_default();
+        Self::set_global(cx, show_table_headers, &status_bar);
         match read_app_preferences() {
             Ok(mut preferences) => {
                 preferences.show_table_headers = show_table_headers;
@@ -166,6 +204,19 @@ impl EditorSettings {
             }
             Err(err) => eprintln!("failed to read table header preference: {err}"),
         }
+    }
+
+    pub fn status_bar_preferences(cx: &App) -> StatusBarPreferences {
+        cx.try_global::<Self>()
+            .map(|s| StatusBarPreferences {
+                enabled: s.status_bar_settings.status_bar_enabled,
+                show_word_count: s.status_bar_settings.status_bar_show_word_count,
+                show_cursor_position: s.status_bar_settings.status_bar_show_cursor_position,
+                show_sidebar_toggle: s.status_bar_settings.status_bar_show_sidebar_toggle,
+                show_mode_switch: s.status_bar_settings.status_bar_show_mode_switch,
+                custom_buttons: Vec::new(),
+            })
+            .unwrap_or_default()
     }
 }
 
@@ -517,6 +568,7 @@ pub(crate) fn save_preferences_from_window(
     default_theme_id: &str,
     image_paste_behavior: ImagePasteBehavior,
     keybindings: BTreeMap<String, Vec<String>>,
+    status_bar: &StatusBarPreferences,
 ) -> anyhow::Result<AppPreferences> {
     let dirs = VelotypeConfigDirs::from_system()?;
     save_preferences_from_window_with_dirs(
@@ -524,6 +576,7 @@ pub(crate) fn save_preferences_from_window(
         default_theme_id,
         image_paste_behavior,
         keybindings,
+        status_bar,
         &dirs,
     )
 }
@@ -533,6 +586,7 @@ fn save_preferences_from_window_with_dirs(
     default_theme_id: &str,
     image_paste_behavior: ImagePasteBehavior,
     keybindings: BTreeMap<String, Vec<String>>,
+    status_bar: &StatusBarPreferences,
     dirs: &VelotypeConfigDirs,
 ) -> anyhow::Result<AppPreferences> {
     let mut preferences =
@@ -541,6 +595,7 @@ fn save_preferences_from_window_with_dirs(
     preferences.default_theme_id = default_theme_id.into();
     preferences.image_paste_behavior = image_paste_behavior;
     preferences.keybindings = normalize_shortcut_config(&keybindings);
+    preferences.status_bar = status_bar.clone();
     save_app_preferences_with_dirs(&preferences, dirs)?;
     Ok(preferences)
 }
@@ -560,6 +615,7 @@ enum PreferencesNav {
     Theme,
     Image,
     Shortcuts,
+    StatusBar,
 }
 
 /// Independent preferences window view.
@@ -580,6 +636,16 @@ pub(crate) struct PreferencesWindow {
     image_dropdown_open: bool,
     recording_shortcut: Option<ShortcutCommand>,
     shortcut_error: Option<String>,
+    status_bar_enabled: bool,
+    status_bar_show_word_count: bool,
+    status_bar_show_cursor_position: bool,
+    status_bar_show_sidebar_toggle: bool,
+    status_bar_show_mode_switch: bool,
+    saved_status_bar_enabled: bool,
+    saved_status_bar_show_word_count: bool,
+    saved_status_bar_show_cursor_position: bool,
+    saved_status_bar_show_sidebar_toggle: bool,
+    saved_status_bar_show_mode_switch: bool,
 }
 
 impl PreferencesWindow {
@@ -616,6 +682,16 @@ impl PreferencesWindow {
             image_dropdown_open: false,
             recording_shortcut: None,
             shortcut_error: None,
+            status_bar_enabled: preferences.status_bar.enabled,
+            status_bar_show_word_count: preferences.status_bar.show_word_count,
+            status_bar_show_cursor_position: preferences.status_bar.show_cursor_position,
+            status_bar_show_sidebar_toggle: preferences.status_bar.show_sidebar_toggle,
+            status_bar_show_mode_switch: preferences.status_bar.show_mode_switch,
+            saved_status_bar_enabled: preferences.status_bar.enabled,
+            saved_status_bar_show_word_count: preferences.status_bar.show_word_count,
+            saved_status_bar_show_cursor_position: preferences.status_bar.show_cursor_position,
+            saved_status_bar_show_sidebar_toggle: preferences.status_bar.show_sidebar_toggle,
+            saved_status_bar_show_mode_switch: preferences.status_bar.show_mode_switch,
         }
     }
 
@@ -633,6 +709,11 @@ impl PreferencesWindow {
             || self.image_paste_behavior != self.saved_image_paste_behavior
             || normalize_shortcut_config(&self.keybindings)
                 != normalize_shortcut_config(&self.saved_keybindings)
+            || self.status_bar_enabled != self.saved_status_bar_enabled
+            || self.status_bar_show_word_count != self.saved_status_bar_show_word_count
+            || self.status_bar_show_cursor_position != self.saved_status_bar_show_cursor_position
+            || self.status_bar_show_sidebar_toggle != self.saved_status_bar_show_sidebar_toggle
+            || self.status_bar_show_mode_switch != self.saved_status_bar_show_mode_switch
     }
 
     fn set_nav_file(&mut self, _: &ClickEvent, _: &mut Window, cx: &mut Context<Self>) {
@@ -668,6 +749,15 @@ impl PreferencesWindow {
         self.theme_dropdown_open = false;
         self.image_dropdown_open = false;
         self.shortcut_error = None;
+        cx.notify();
+    }
+
+    fn set_nav_status_bar(&mut self, _: &ClickEvent, _: &mut Window, cx: &mut Context<Self>) {
+        self.nav = PreferencesNav::StatusBar;
+        self.startup_dropdown_open = false;
+        self.theme_dropdown_open = false;
+        self.image_dropdown_open = false;
+        self.recording_shortcut = None;
         cx.notify();
     }
 
@@ -717,6 +807,14 @@ impl PreferencesWindow {
             &self.selected_theme_id,
             self.image_paste_behavior,
             self.keybindings.clone(),
+            &StatusBarPreferences {
+                enabled: self.status_bar_enabled,
+                show_word_count: self.status_bar_show_word_count,
+                show_cursor_position: self.status_bar_show_cursor_position,
+                show_sidebar_toggle: self.status_bar_show_sidebar_toggle,
+                show_mode_switch: self.status_bar_show_mode_switch,
+                custom_buttons: Vec::new(),
+            },
         ) {
             Ok(preferences) => preferences,
             Err(err) => {
@@ -754,6 +852,13 @@ impl PreferencesWindow {
         cx.clear_key_bindings();
         install_keybindings(cx, &preferences.keybindings);
         crate::app_menu::install_menus(cx);
+        cx.update_global::<EditorSettings, _>(|settings, _cx| {
+            settings.status_bar_settings.status_bar_enabled = preferences.status_bar.enabled;
+            settings.status_bar_settings.status_bar_show_word_count = preferences.status_bar.show_word_count;
+            settings.status_bar_settings.status_bar_show_cursor_position = preferences.status_bar.show_cursor_position;
+            settings.status_bar_settings.status_bar_show_sidebar_toggle = preferences.status_bar.show_sidebar_toggle;
+            settings.status_bar_settings.status_bar_show_mode_switch = preferences.status_bar.show_mode_switch;
+        });
         cx.refresh_windows();
         window.activate_window();
         self.focus_handle.focus(window);
@@ -761,6 +866,11 @@ impl PreferencesWindow {
         self.saved_theme_id = self.selected_theme_id.clone();
         self.saved_image_paste_behavior = self.image_paste_behavior;
         self.saved_keybindings = normalize_shortcut_config(&self.keybindings);
+        self.saved_status_bar_enabled = self.status_bar_enabled;
+        self.saved_status_bar_show_word_count = self.status_bar_show_word_count;
+        self.saved_status_bar_show_cursor_position = self.status_bar_show_cursor_position;
+        self.saved_status_bar_show_sidebar_toggle = self.status_bar_show_sidebar_toggle;
+        self.saved_status_bar_show_mode_switch = self.status_bar_show_mode_switch;
         cx.notify();
     }
 
@@ -1440,6 +1550,96 @@ impl PreferencesWindow {
         }
         page.child(content)
     }
+
+    fn render_status_bar_page(
+        &self,
+        theme: &Theme,
+        strings: &crate::i18n::I18nStrings,
+        cx: &mut Context<Self>,
+    ) -> Div {
+        let c = &theme.colors;
+        let t = &theme.typography;
+
+        let switch_row = |label: &str, checked: bool, on_click: fn(&mut Self, &ClickEvent, &mut Window, &mut Context<Self>), cx: &mut Context<Self>| {
+            div()
+                .w(px(280.0))
+                .flex()
+                .items_center()
+                .justify_between()
+                .child(
+                    div()
+                        .text_size(px(t.dialog_body_size))
+                        .text_color(c.dialog_body)
+                        .child(SharedString::from(label.to_string())),
+                )
+                .child(
+                    Switch::new(ElementId::Name(
+                        format!("preferences-toggle-{}", label).into(),
+                    ))
+                    .checked(checked)
+                    .on_click(cx.listener(on_click)),
+                )
+        };
+
+        let items = div()
+            .flex()
+            .flex_col()
+            .gap(px(12.0))
+            .child(switch_row(
+                &strings.preferences_status_bar_enabled,
+                self.status_bar_enabled,
+                |this, _, _, cx| {
+                    this.status_bar_enabled = !this.status_bar_enabled;
+                    cx.notify();
+                },
+                cx,
+            ))
+            .child(switch_row(
+                &strings.preferences_status_bar_show_word_count,
+                self.status_bar_show_word_count,
+                |this, _, _, cx| {
+                    this.status_bar_show_word_count = !this.status_bar_show_word_count;
+                    cx.notify();
+                },
+                cx,
+            ))
+            .child(switch_row(
+                &strings.preferences_status_bar_show_cursor_position,
+                self.status_bar_show_cursor_position,
+                |this, _, _, cx| {
+                    this.status_bar_show_cursor_position = !this.status_bar_show_cursor_position;
+                    cx.notify();
+                },
+                cx,
+            ))
+            .child(switch_row(
+                &strings.preferences_status_bar_show_sidebar_toggle,
+                self.status_bar_show_sidebar_toggle,
+                |this, _, _, cx| {
+                    this.status_bar_show_sidebar_toggle = !this.status_bar_show_sidebar_toggle;
+                    cx.notify();
+                },
+                cx,
+            ))
+            .child(switch_row(
+                &strings.preferences_status_bar_show_mode_switch,
+                self.status_bar_show_mode_switch,
+                |this, _, _, cx| {
+                    this.status_bar_show_mode_switch = !this.status_bar_show_mode_switch;
+                    cx.notify();
+                },
+                cx,
+            ));
+
+        div()
+            .w_full()
+            .flex_1()
+            .min_h(px(0.0))
+            .flex()
+            .items_center()
+            .justify_center()
+            .child(items)
+    }
 }
 
 impl Render for PreferencesWindow {
@@ -1510,6 +1710,14 @@ impl Render for PreferencesWindow {
                                 &theme,
                                 Self::set_nav_shortcuts,
                                 cx,
+                            ))
+                            .child(self.nav_button(
+                                "preferences-nav-status-bar",
+                                strings.preferences_nav_status_bar.clone(),
+                                self.nav == PreferencesNav::StatusBar,
+                                &theme,
+                                Self::set_nav_status_bar,
+                                cx,
                             )),
                     ),
             )
@@ -1549,6 +1757,9 @@ impl Render for PreferencesWindow {
                                         PreferencesNav::Shortcuts => {
                                             strings.preferences_nav_shortcuts.clone()
                                         }
+                                        PreferencesNav::StatusBar => {
+                                            strings.preferences_nav_status_bar.clone()
+                                        }
                                     }),
                             )
                             .child(match self.nav {
@@ -1584,6 +1795,15 @@ impl Render for PreferencesWindow {
                                     .flex_1()
                                     .min_h(px(0.0))
                                     .child(self.render_shortcuts_page(&theme, &strings, cx))
+                                    .into_any_element(),
+                                PreferencesNav::StatusBar => div()
+                                    .w_full()
+                                    .flex_1()
+                                    .min_h(px(0.0))
+                                    .flex()
+                                    .items_center()
+                                    .justify_center()
+                                    .child(self.render_status_bar_page(&theme, &strings, cx))
                                     .into_any_element(),
                             }),
                     )
@@ -1719,10 +1939,10 @@ pub(crate) fn open_preferences_window(cx: &mut App) -> WindowHandle<PreferencesW
 #[cfg(test)]
 mod tests {
     use super::{
-        AppPreferences, ImagePasteBehavior, StartupOpenPreference, StatusBarPreferences,
-        load_or_create_app_preferences_with_dirs_and_locales, open_preferences_window_with_state,
-        read_app_preferences_with_dirs, save_app_preferences_with_dirs,
-        save_preferences_from_window_with_dirs,
+        AppPreferences, EditorSettings, ImagePasteBehavior, StartupOpenPreference,
+        StatusBarPreferences, load_or_create_app_preferences_with_dirs_and_locales,
+        open_preferences_window_with_state, read_app_preferences_with_dirs,
+        save_app_preferences_with_dirs, save_preferences_from_window_with_dirs,
     };
     use crate::config::VelotypeConfigDirs;
     use crate::i18n::I18nManager;
@@ -1735,6 +1955,7 @@ mod tests {
             I18nManager::init_with_language_id(cx, "en-US");
             ThemeManager::init_with_theme_id(cx, "velotype");
             crate::components::init(cx);
+            EditorSettings::init(cx, true);
         });
     }
 
@@ -1934,6 +2155,7 @@ mod tests {
             "velotype-light",
             ImagePasteBehavior::CopyToNamedAssetsFolder,
             BTreeMap::from([("save_document".to_string(), vec!["ctrl-alt-s".to_string()])]),
+            &StatusBarPreferences::default(),
             &dirs,
         )
         .expect("window preferences should save");

--- a/src/config/preferences.rs
+++ b/src/config/preferences.rs
@@ -170,7 +170,7 @@ impl EditorSettings {
                 status_bar_show_cursor_position: status_bar.show_cursor_position,
                 status_bar_show_sidebar_toggle: status_bar.show_sidebar_toggle,
                 status_bar_show_mode_switch: status_bar.show_mode_switch,
-            }
+            },
         });
     }
 
@@ -854,10 +854,14 @@ impl PreferencesWindow {
         crate::app_menu::install_menus(cx);
         cx.update_global::<EditorSettings, _>(|settings, _cx| {
             settings.status_bar_settings.status_bar_enabled = preferences.status_bar.enabled;
-            settings.status_bar_settings.status_bar_show_word_count = preferences.status_bar.show_word_count;
-            settings.status_bar_settings.status_bar_show_cursor_position = preferences.status_bar.show_cursor_position;
-            settings.status_bar_settings.status_bar_show_sidebar_toggle = preferences.status_bar.show_sidebar_toggle;
-            settings.status_bar_settings.status_bar_show_mode_switch = preferences.status_bar.show_mode_switch;
+            settings.status_bar_settings.status_bar_show_word_count =
+                preferences.status_bar.show_word_count;
+            settings.status_bar_settings.status_bar_show_cursor_position =
+                preferences.status_bar.show_cursor_position;
+            settings.status_bar_settings.status_bar_show_sidebar_toggle =
+                preferences.status_bar.show_sidebar_toggle;
+            settings.status_bar_settings.status_bar_show_mode_switch =
+                preferences.status_bar.show_mode_switch;
         });
         cx.refresh_windows();
         window.activate_window();
@@ -1560,7 +1564,10 @@ impl PreferencesWindow {
         let c = &theme.colors;
         let t = &theme.typography;
 
-        let switch_row = |label: &str, checked: bool, on_click: fn(&mut Self, &ClickEvent, &mut Window, &mut Context<Self>), cx: &mut Context<Self>| {
+        let switch_row = |label: &str,
+                          checked: bool,
+                          on_click: fn(&mut Self, &ClickEvent, &mut Window, &mut Context<Self>),
+                          cx: &mut Context<Self>| {
             div()
                 .w(px(280.0))
                 .flex()

--- a/src/editor/events.rs
+++ b/src/editor/events.rs
@@ -992,15 +992,6 @@ impl Editor {
         self.clear_table_axis_selection(cx);
     }
 
-    pub(crate) fn on_view_mode_toggle_hover(
-        &mut self,
-        hovered: &bool,
-        _window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        self.set_view_mode_toggle_hovered(*hovered, cx);
-    }
-
     pub(crate) fn on_editor_scroll_wheel(
         &mut self,
         _event: &ScrollWheelEvent,

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -42,8 +42,10 @@ mod tree;
 mod update;
 mod window_state;
 mod workspace;
+mod status_bar;
 
 use self::workspace::WorkspaceState;
+use self::status_bar::StatusBarState;
 
 /// Link navigation request deferred until a `Window` is available.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -93,6 +95,7 @@ pub struct Editor {
     /// True while an online update check is running in the background.
     update_check_in_progress: bool,
     workspace: WorkspaceState,
+    status_bar: StatusBarState,
     context_menu: Option<ContextMenuState>,
     table_insert_dialog: Option<TableInsertDialogState>,
     context_menu_submenu_close_task: Option<Task<()>>,
@@ -114,7 +117,6 @@ pub struct Editor {
     /// cannot clobber a single shared flag and tear the menu down.
     menu_submenu_bridge_hovered: bool,
     menu_close_task: Option<Task<()>>,
-    view_mode_toggle_hovered: bool,
     scrollbar_hovered: bool,
     scrollbar_visible_until: Instant,
     scrollbar_fade_task: Option<Task<()>>,
@@ -290,6 +292,7 @@ impl Editor {
             info_dialog: None,
             update_check_in_progress: false,
             workspace: WorkspaceState::default(),
+            status_bar: StatusBarState::default(),
             context_menu: None,
             table_insert_dialog: None,
             context_menu_submenu_close_task: None,
@@ -305,7 +308,6 @@ impl Editor {
             menu_submenu_panel_hovered: false,
             menu_submenu_bridge_hovered: false,
             menu_close_task: None,
-            view_mode_toggle_hovered: false,
             scrollbar_hovered: false,
             scrollbar_visible_until: Instant::now(),
             scrollbar_fade_task: None,

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -35,6 +35,7 @@ mod render;
 mod runtime_context;
 mod selection;
 mod source_mapping;
+mod status_bar;
 mod table_edit;
 #[cfg(test)]
 mod tests;
@@ -42,10 +43,9 @@ mod tree;
 mod update;
 mod window_state;
 mod workspace;
-mod status_bar;
 
-use self::workspace::WorkspaceState;
 use self::status_bar::StatusBarState;
+use self::workspace::WorkspaceState;
 
 /// Link navigation request deferred until a `Window` is available.
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/editor/render.rs
+++ b/src/editor/render.rs
@@ -1527,7 +1527,6 @@ impl Render for Editor {
         self.sync_window_title(window, &strings);
 
         let d = &theme.dimensions;
-        let c = &theme.colors;
         let visible_blocks = self.document.visible_blocks().to_vec();
         let editor = cx.entity().downgrade();
         let has_menus = cx
@@ -1861,46 +1860,6 @@ impl Render for Editor {
             content_area
         };
 
-        // View-mode toggle button — bottom-left corner of the editor.
-        let toggle_label = match (self.view_mode, self.view_mode_toggle_hovered) {
-            (super::ViewMode::Rendered, false) => strings.view_mode_source.clone(),
-            (super::ViewMode::Rendered, true) => strings.view_mode_switch_to_source.clone(),
-            (super::ViewMode::Source, false) => strings.view_mode_rendered.clone(),
-            (super::ViewMode::Source, true) => strings.view_mode_switch_to_rendered.clone(),
-        };
-        let view_mode_toggle = div()
-            .id("view-mode-toggle")
-            .absolute()
-            .left(px(d.view_mode_toggle_left))
-            .bottom(px(d.view_mode_toggle_bottom))
-            .occlude()
-            .min_w(px(d.view_mode_toggle_min_width))
-            .px(px(d.view_mode_toggle_padding_x))
-            .py(px(d.view_mode_toggle_padding_y))
-            .flex()
-            .items_center()
-            .justify_center()
-            .rounded(px(d.view_mode_toggle_radius))
-            .bg(if self.view_mode_toggle_hovered {
-                c.dialog_secondary_button_hover
-            } else {
-                c.dialog_surface
-            })
-            .border(px(d.view_mode_toggle_border_width))
-            .border_color(c.dialog_border.opacity(0.65))
-            .cursor_pointer()
-            .text_size(px(d.view_mode_toggle_text_size))
-            .text_color(if self.view_mode_toggle_hovered {
-                c.dialog_secondary_button_text
-            } else {
-                c.dialog_muted
-            })
-            .whitespace_nowrap()
-            .on_hover(cx.listener(Self::on_view_mode_toggle_hover))
-            .child(SharedString::from(toggle_label))
-            .on_click(cx.listener(Self::on_toggle_view_mode));
-        let content_area = content_area.child(view_mode_toggle);
-
         // Repaint when the Cmd/Ctrl follow modifier toggles so a hovered link's
         // hand cursor updates without moving the pointer. `ModifiersChanged` is
         // dispatched along the focused element's path to the root, and this root
@@ -1912,6 +1871,8 @@ impl Render for Editor {
         let base = div()
             .w_full()
             .h_full()
+            .flex()
+            .flex_col()
             .relative()
             .bg(theme.colors.editor_background)
             .font(editor_text_font())
@@ -1986,7 +1947,8 @@ impl Render for Editor {
             workspace_panel_width_for_viewport(f32::from(window.viewport_size().width));
         let main_content = div()
             .w_full()
-            .h_full()
+            .flex_1()
+            .min_h(px(0.0))
             .pt(px(titlebar_height + menu_bar_height))
             .flex()
             .min_w(px(0.0));
@@ -1998,6 +1960,13 @@ impl Render for Editor {
             main_content
         };
         let base = base.child(main_content.child(content_area));
+        let base = if let Some(status_bar) =
+            self.render_status_bar(&theme, &strings, window, cx)
+        {
+            base.child(status_bar)
+        } else {
+            base
+        };
         let base = if let Some(menu_panel) = self.render_in_window_menu_panel(
             &theme,
             cx,

--- a/src/editor/render.rs
+++ b/src/editor/render.rs
@@ -1960,9 +1960,7 @@ impl Render for Editor {
             main_content
         };
         let base = base.child(main_content.child(content_area));
-        let base = if let Some(status_bar) =
-            self.render_status_bar(&theme, &strings, window, cx)
-        {
+        let base = if let Some(status_bar) = self.render_status_bar(&theme, &strings, window, cx) {
             base.child(status_bar)
         } else {
             base

--- a/src/editor/selection.rs
+++ b/src/editor/selection.rs
@@ -699,7 +699,7 @@ impl Editor {
         true
     }
 
-    fn cross_block_selected_markdown(&self, cx: &App) -> Option<String> {
+    pub(super) fn cross_block_selected_markdown(&self, cx: &App) -> Option<String> {
         let selection = self.normalized_cross_block_selection(cx)?;
         let source = self.current_document_source(cx);
         let mappings = self.source_mapping_by_entity_id(cx);
@@ -871,6 +871,35 @@ impl Editor {
         self.sync_cross_block_selection_visuals(cx);
         cx.notify();
         true
+    }
+
+    /// Returns the markdown text of the current selection, whether cross-block
+    /// or within a single block. Returns `None` when nothing is selected.
+    pub(super) fn selected_markdown_text(&self, cx: &App) -> Option<String> {
+        // Prefer cross-block selection when present.
+        if let Some(text) = self.cross_block_selected_markdown(cx) {
+            if !text.is_empty() {
+                return Some(text);
+            }
+        }
+
+        // Fall back to a single block with a non-collapsed selection range.
+        for visible in self.document.visible_blocks() {
+            let block = visible.entity.read(cx);
+            if block.selected_range.is_empty() {
+                continue;
+            }
+            let markdown_range =
+                block.current_range_to_markdown_range(block.selected_range.clone());
+            let full_markdown = block.record.title.serialize_markdown();
+            let start = markdown_range.start.min(full_markdown.len());
+            let end = markdown_range.end.min(full_markdown.len());
+            if start < end {
+                return Some(full_markdown[start..end].to_owned());
+            }
+        }
+
+        None
     }
 }
 

--- a/src/editor/status_bar.rs
+++ b/src/editor/status_bar.rs
@@ -1,0 +1,382 @@
+//! Bottom status bar: sidebar toggle, mode switch, cursor position,
+//! word count, and custom buttons.
+
+use gpui::*;
+use unicode_segmentation::UnicodeSegmentation;
+
+use super::Editor;
+use crate::config::preferences::{StatusBarButton, StatusBarPreferences};
+use crate::i18n::I18nStrings;
+use crate::theme::Theme;
+
+#[derive(Default)]
+pub(super) struct StatusBarState {
+    pub sidebar_hovered: bool,
+    pub mode_hovered: bool,
+    custom_button_hovered: Option<String>,
+}
+
+impl Editor {
+    pub(super) fn render_status_bar(
+        &mut self,
+        theme: &Theme,
+        strings: &I18nStrings,
+        _window: &Window,
+        cx: &mut Context<Self>,
+    ) -> Option<AnyElement> {
+        let prefs = self.status_bar_preferences();
+        if !prefs.enabled {
+            return None;
+        }
+
+        let c = &theme.colors;
+        let d = &theme.dimensions;
+
+        let mut left_items: Vec<AnyElement> = Vec::new();
+
+        if prefs.show_sidebar_toggle {
+            left_items.push(render_sidebar_toggle(
+                &mut self.status_bar,
+                self.workspace.is_open,
+                theme,
+                strings,
+                cx,
+            ));
+        }
+
+        if prefs.show_mode_switch {
+            left_items.push(render_mode_switch(
+                &mut self.status_bar,
+                self.view_mode,
+                theme,
+                strings,
+                cx,
+            ));
+        }
+
+        let mut right_items: Vec<AnyElement> = Vec::new();
+
+        if prefs.show_cursor_position && self.view_mode == super::ViewMode::Source {
+            right_items.push(render_cursor(
+                self.compute_source_cursor_position(cx),
+                theme,
+            ));
+        }
+
+        if prefs.show_word_count {
+            let text = self.serialized_document_text(cx);
+            right_items.push(render_word_count(&text, theme, strings));
+        }
+
+        for button in &prefs.custom_buttons {
+            right_items.push(render_custom_button(
+                &mut self.status_bar,
+                button,
+                theme,
+                cx,
+            ));
+        }
+
+        let bar = div()
+            .id("status-bar")
+            .h(px(d.status_bar_height))
+            .w_full()
+            .flex_shrink_0()
+            .flex()
+            .items_center()
+            .justify_between()
+            .px(px(d.status_bar_padding_x))
+            .bg(c.status_bar_background)
+            .border_t(px(1.0))
+            .border_color(c.dialog_border)
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap(px(d.status_bar_item_gap))
+                    .children(left_items),
+            )
+            .child(
+                div()
+                    .flex()
+                    .items_center()
+                    .gap(px(d.status_bar_item_gap))
+                    .children(right_items),
+            )
+            .into_any_element();
+
+        Some(bar)
+    }
+
+    fn status_bar_preferences(&self) -> StatusBarPreferences {
+        StatusBarPreferences::default()
+    }
+
+    /// Returns (line, col), both 1-based, from the source-mode selection snapshot.
+    fn compute_source_cursor_position(&self, cx: &App) -> (usize, usize) {
+        let snapshot = self.capture_source_selection_snapshot(cx);
+        let cursor_offset = snapshot.range.end;
+        let text = self.document.raw_source_text(cx);
+        let clamped = cursor_offset.min(text.len());
+
+        let line = text[..clamped].matches('\n').count() + 1;
+        let last_newline = text[..clamped].rfind('\n').map(|i| i + 1).unwrap_or(0);
+        let col = text[last_newline..clamped].graphemes(true).count() + 1;
+        (line, col)
+    }
+}
+
+fn render_sidebar_toggle(
+    state: &mut StatusBarState,
+    _is_open: bool,
+    theme: &Theme,
+    strings: &I18nStrings,
+    cx: &mut Context<Editor>,
+) -> AnyElement {
+    let c = &theme.colors;
+    let d = &theme.dimensions;
+
+    div()
+        .id("status-bar-sidebar-toggle")
+        .h(px(d.status_bar_height - 4.0))
+        .px(px(6.0))
+        .flex()
+        .items_center()
+        .rounded(px(4.0))
+        .bg(if state.sidebar_hovered {
+            c.status_bar_button_hover
+        } else {
+            hsla(0., 0., 0., 0.)
+        })
+        .cursor_pointer()
+        .text_size(px(d.status_bar_text_size))
+        .text_color(c.status_bar_text)
+        .child(strings.status_bar_files.clone())
+        .on_hover(cx.listener(
+            |editor: &mut Editor,
+             hovered: &bool,
+             _window: &mut Window,
+             cx: &mut Context<Editor>| {
+                editor.status_bar.sidebar_hovered = *hovered;
+                cx.notify();
+            },
+        ))
+        .on_click(cx.listener(
+            |editor: &mut Editor,
+             _: &gpui::ClickEvent,
+             window: &mut Window,
+             cx: &mut Context<Editor>| {
+                editor.toggle_workspace_drawer(window, cx);
+            },
+        ))
+        .into_any_element()
+}
+
+fn render_mode_switch(
+    state: &mut StatusBarState,
+    view_mode: super::ViewMode,
+    theme: &Theme,
+    strings: &I18nStrings,
+    cx: &mut Context<Editor>,
+) -> AnyElement {
+    let c = &theme.colors;
+    let d = &theme.dimensions;
+
+    let label = match view_mode {
+        super::ViewMode::Source => strings.status_bar_mode_rendered.clone(),
+        super::ViewMode::Rendered => strings.status_bar_mode_source.clone(),
+    };
+
+    div()
+        .id("status-bar-mode-switch")
+        .h(px(d.status_bar_height - 4.0))
+        .px(px(6.0))
+        .flex()
+        .items_center()
+        .rounded(px(4.0))
+        .bg(if state.mode_hovered {
+            c.status_bar_button_hover
+        } else {
+            hsla(0., 0., 0., 0.)
+        })
+        .cursor_pointer()
+        .text_size(px(d.status_bar_text_size))
+        .text_color(c.status_bar_text)
+        .child(label)
+        .on_hover(cx.listener(
+            |editor: &mut Editor,
+             hovered: &bool,
+             _window: &mut Window,
+             cx: &mut Context<Editor>| {
+                editor.status_bar.mode_hovered = *hovered;
+                cx.notify();
+            },
+        ))
+        .on_click(cx.listener(
+            |editor: &mut Editor,
+             _: &gpui::ClickEvent,
+             _window: &mut Window,
+             cx: &mut Context<Editor>| {
+                editor.toggle_view_mode_from_ui(cx);
+            },
+        ))
+        .into_any_element()
+}
+
+fn render_cursor((line, col): (usize, usize), theme: &Theme) -> AnyElement {
+    let c = &theme.colors;
+    let d = &theme.dimensions;
+
+    let label = format!("{} : {}", &line.to_string(), &col.to_string());
+
+    div()
+        .text_size(px(d.status_bar_text_size))
+        .text_color(c.status_bar_text)
+        .child(label)
+        .into_any_element()
+}
+
+fn render_word_count(text: &str, theme: &Theme, strings: &I18nStrings) -> AnyElement {
+    let c = &theme.colors;
+    let d = &theme.dimensions;
+
+    let count = count_words(text);
+    let label = format!("{} {}", count, strings.status_bar_word_count_suffix);
+
+    div()
+        .text_size(px(d.status_bar_text_size))
+        .text_color(c.status_bar_text_dim)
+        .child(label)
+        .into_any_element()
+}
+
+fn render_custom_button(
+    state: &mut StatusBarState,
+    button: &StatusBarButton,
+    theme: &Theme,
+    cx: &mut Context<Editor>,
+) -> AnyElement {
+    let c = &theme.colors;
+    let d = &theme.dimensions;
+
+    let id = button.id.clone();
+    let hovered = state.custom_button_hovered.as_deref() == Some(&button.id);
+
+    div()
+        .id(ElementId::Name(
+            format!("status-bar-custom-button-{}", button.id).into(),
+        ))
+        .h(px(d.status_bar_height - 4.0))
+        .px(px(6.0))
+        .flex()
+        .items_center()
+        .rounded(px(4.0))
+        .bg(if hovered {
+            c.status_bar_button_hover
+        } else {
+            hsla(0., 0., 0., 0.)
+        })
+        .cursor_pointer()
+        .text_size(px(d.status_bar_text_size))
+        .text_color(c.status_bar_text)
+        .child(button.label.clone())
+        .on_hover(cx.listener(
+            move |editor: &mut Editor,
+                  hovered: &bool,
+                  _window: &mut Window,
+                  cx: &mut Context<Editor>| {
+                if *hovered {
+                    editor.status_bar.custom_button_hovered = Some(id.clone());
+                } else if editor.status_bar.custom_button_hovered.as_deref() == Some(&id) {
+                    editor.status_bar.custom_button_hovered = None;
+                }
+                cx.notify();
+            },
+        ))
+        .into_any_element()
+}
+
+/// Count words in mixed CJK / Latin text.
+///
+/// Every CJK character counts as one word. Latin words are split on whitespace.
+pub fn count_words(text: &str) -> usize {
+    let mut count = 0;
+    let mut in_latin_word = false;
+
+    for ch in text.chars() {
+        if is_cjk_char(ch) {
+            if in_latin_word {
+                count += 1;
+                in_latin_word = false;
+            }
+            count += 1;
+        } else if ch.is_whitespace() {
+            if in_latin_word {
+                count += 1;
+                in_latin_word = false;
+            }
+        } else {
+            in_latin_word = true;
+        }
+    }
+    if in_latin_word {
+        count += 1;
+    }
+    count
+}
+
+fn is_cjk_char(ch: char) -> bool {
+    matches!(
+        ch as u32,
+        // CJK Unified Ideographs
+        0x4E00..=0x9FFF
+        // CJK Unified Ideographs Extension A
+        | 0x3400..=0x4DBF
+        // CJK Unified Ideographs Extension B
+        | 0x20000..=0x2A6DF
+        // CJK Compatibility Ideographs
+        | 0xF900..=0xFAFF
+        // CJK Radicals Supplement / Kangxi Radicals
+        | 0x2E80..=0x2EFF
+        | 0x2F00..=0x2FDF
+        // Hiragana / Katakana (Japanese)
+        | 0x3040..=0x309F
+        | 0x30A0..=0x30FF
+        // Hangul Syllables (Korean)
+        | 0xAC00..=0xD7AF
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::count_words;
+
+    #[test]
+    fn empty_text_has_zero_words() {
+        assert_eq!(count_words(""), 0);
+    }
+
+    #[test]
+    fn english_words_are_counted() {
+        assert_eq!(count_words("hello world"), 2);
+        assert_eq!(count_words("one two three four"), 4);
+    }
+
+    #[test]
+    fn cjk_characters_are_counted_individually() {
+        assert_eq!(count_words("你好世界"), 4);
+        assert_eq!(count_words("中文"), 2);
+    }
+
+    #[test]
+    fn mixed_cjk_and_english() {
+        assert_eq!(count_words("hello 世界"), 3);
+        assert_eq!(count_words("你好 world foo"), 4);
+    }
+
+    #[test]
+    fn whitespace_handling() {
+        assert_eq!(count_words("  hello   world  "), 2);
+        assert_eq!(count_words("   "), 0);
+    }
+}

--- a/src/editor/status_bar.rs
+++ b/src/editor/status_bar.rs
@@ -65,7 +65,14 @@ impl Editor {
 
         if prefs.show_word_count {
             let text = self.serialized_document_text(cx);
-            right_items.push(render_word_count(&text, theme, strings));
+            let total_count = count_words(&text);
+            let selection_count = self.selected_markdown_text(cx).as_deref().map(count_words);
+            right_items.push(render_word_count(
+                selection_count,
+                total_count,
+                theme,
+                strings,
+            ));
         }
 
         for button in &prefs.custom_buttons {
@@ -236,12 +243,23 @@ fn render_cursor((line, col): (usize, usize), theme: &Theme) -> AnyElement {
         .into_any_element()
 }
 
-fn render_word_count(text: &str, theme: &Theme, strings: &I18nStrings) -> AnyElement {
+fn render_word_count(
+    selection_count: Option<usize>,
+    total_count: usize,
+    theme: &Theme,
+    strings: &I18nStrings,
+) -> AnyElement {
     let c = &theme.colors;
     let d = &theme.dimensions;
 
-    let count = count_words(text);
-    let label = format!("{} {}", count, strings.status_bar_word_count_suffix);
+    let label = if let Some(sel) = selection_count {
+        format!(
+            "{} / {} {}",
+            sel, total_count, strings.status_bar_word_count_suffix
+        )
+    } else {
+        format!("{} {}", total_count, strings.status_bar_word_count_suffix)
+    };
 
     div()
         .text_size(px(d.status_bar_text_size))

--- a/src/editor/status_bar.rs
+++ b/src/editor/status_bar.rs
@@ -24,7 +24,7 @@ impl Editor {
         _window: &Window,
         cx: &mut Context<Self>,
     ) -> Option<AnyElement> {
-        let prefs = self.status_bar_preferences();
+        let prefs = self.status_bar_preferences(cx);
         if !prefs.enabled {
             return None;
         }
@@ -108,8 +108,8 @@ impl Editor {
         Some(bar)
     }
 
-    fn status_bar_preferences(&self) -> StatusBarPreferences {
-        StatusBarPreferences::default()
+    fn status_bar_preferences(&self, cx: &App) -> StatusBarPreferences {
+        crate::config::preferences::EditorSettings::status_bar_preferences(cx)
     }
 
     /// Returns (line, col), both 1-based, from the source-mode selection snapshot.

--- a/src/editor/window_state.rs
+++ b/src/editor/window_state.rs
@@ -102,15 +102,6 @@ impl Editor {
         }
     }
 
-    pub(crate) fn on_toggle_view_mode(
-        &mut self,
-        _: &ClickEvent,
-        _window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        self.toggle_view_mode_from_ui(cx);
-    }
-
     pub(crate) fn on_toggle_view_mode_action(
         &mut self,
         _: &crate::components::ToggleViewMode,
@@ -120,7 +111,7 @@ impl Editor {
         self.toggle_view_mode_from_ui(cx);
     }
 
-    fn toggle_view_mode_from_ui(&mut self, cx: &mut Context<Self>) {
+    pub(super) fn toggle_view_mode_from_ui(&mut self, cx: &mut Context<Self>) {
         self.end_block_pointer_selection_sessions(cx);
         self.last_selection_snapshot = self.capture_source_selection_snapshot(cx);
         self.toggle_view_mode(cx);
@@ -444,13 +435,6 @@ impl Editor {
             open_target,
         });
         cx.notify();
-    }
-
-    pub(crate) fn set_view_mode_toggle_hovered(&mut self, hovered: bool, cx: &mut Context<Self>) {
-        if self.view_mode_toggle_hovered != hovered {
-            self.view_mode_toggle_hovered = hovered;
-            cx.notify();
-        }
     }
 
     pub(crate) fn close_menu_bar(&mut self, cx: &mut Context<Self>) {

--- a/src/editor/workspace.rs
+++ b/src/editor/workspace.rs
@@ -49,7 +49,7 @@ enum WorkspaceSelection {
 
 #[derive(Default)]
 pub(super) struct WorkspaceState {
-    is_open: bool,
+    pub(super) is_open: bool,
     active_tab: WorkspaceTab,
     root: Option<PathBuf>,
     file_tree: Option<WorkspaceTreeNode>,

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -301,6 +301,14 @@ pub struct I18nStrings {
     pub image_loading_with_alt_template: String,
     /// Placeholder shown in the code-block language input when no language is set.
     pub code_language_placeholder: String,
+    /// Label for the sidebar/files toggle button in the status bar.
+    pub status_bar_files: String,
+    /// Label for source mode in the status bar mode switch.
+    pub status_bar_mode_source: String,
+    /// Label for rendered mode in the status bar mode switch.
+    pub status_bar_mode_rendered: String,
+    /// Suffix shown after the word count number.
+    pub status_bar_word_count_suffix: String,
 }
 
 /// Partial string set used by JSON language packs.
@@ -478,6 +486,10 @@ struct I18nStringsDe {
     image_loading_without_alt: Option<String>,
     image_loading_with_alt_template: Option<String>,
     code_language_placeholder: Option<String>,
+    status_bar_files: Option<String>,
+    status_bar_mode_source: Option<String>,
+    status_bar_mode_rendered: Option<String>,
+    status_bar_word_count_suffix: Option<String>,
 }
 
 const I18N_STRING_KEYS: &[&str] = &[
@@ -653,6 +665,10 @@ const I18N_STRING_KEYS: &[&str] = &[
     "image_loading_without_alt",
     "image_loading_with_alt_template",
     "code_language_placeholder",
+    "status_bar_files",
+    "status_bar_mode_source",
+    "status_bar_mode_rendered",
+    "status_bar_word_count_suffix",
 ];
 
 impl I18nStringsDe {
@@ -1118,6 +1134,18 @@ impl I18nStringsDe {
             code_language_placeholder: self
                 .code_language_placeholder
                 .unwrap_or(defaults.code_language_placeholder),
+            status_bar_files: self
+                .status_bar_files
+                .unwrap_or(defaults.status_bar_files),
+            status_bar_mode_source: self
+                .status_bar_mode_source
+                .unwrap_or(defaults.status_bar_mode_source),
+            status_bar_mode_rendered: self
+                .status_bar_mode_rendered
+                .unwrap_or(defaults.status_bar_mode_rendered),
+            status_bar_word_count_suffix: self
+                .status_bar_word_count_suffix
+                .unwrap_or(defaults.status_bar_word_count_suffix),
         }
     }
 }
@@ -1306,6 +1334,10 @@ impl I18nStrings {
             image_loading_without_alt: "正在加载图片...".into(),
             image_loading_with_alt_template: "正在加载 {alt}".into(),
             code_language_placeholder: "语言".into(),
+            status_bar_files: "文件".into(),
+            status_bar_mode_source: "源码".into(),
+            status_bar_mode_rendered: "渲染".into(),
+            status_bar_word_count_suffix: "字".into(),
             ..Self::en_us()
         };
         strings.image_paste_failed_title = "图片粘贴失败".into();
@@ -1511,6 +1543,10 @@ impl I18nStrings {
             image_loading_without_alt: "Loading image...".into(),
             image_loading_with_alt_template: "Loading {alt}".into(),
             code_language_placeholder: "language".into(),
+            status_bar_files: "Files".into(),
+            status_bar_mode_source: "Source".into(),
+            status_bar_mode_rendered: "Rendered".into(),
+            status_bar_word_count_suffix: "words".into(),
         }
     }
 

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -1158,9 +1158,7 @@ impl I18nStringsDe {
             code_language_placeholder: self
                 .code_language_placeholder
                 .unwrap_or(defaults.code_language_placeholder),
-            status_bar_files: self
-                .status_bar_files
-                .unwrap_or(defaults.status_bar_files),
+            status_bar_files: self.status_bar_files.unwrap_or(defaults.status_bar_files),
             status_bar_mode_source: self
                 .status_bar_mode_source
                 .unwrap_or(defaults.status_bar_mode_source),

--- a/src/i18n/mod.rs
+++ b/src/i18n/mod.rs
@@ -309,6 +309,18 @@ pub struct I18nStrings {
     pub status_bar_mode_rendered: String,
     /// Suffix shown after the word count number.
     pub status_bar_word_count_suffix: String,
+    /// Nav label for the status bar preferences tab.
+    pub preferences_nav_status_bar: String,
+    /// Label for the status bar enabled toggle.
+    pub preferences_status_bar_enabled: String,
+    /// Label for the word count toggle.
+    pub preferences_status_bar_show_word_count: String,
+    /// Label for the cursor position toggle.
+    pub preferences_status_bar_show_cursor_position: String,
+    /// Label for the sidebar toggle visibility.
+    pub preferences_status_bar_show_sidebar_toggle: String,
+    /// Label for the mode switch visibility.
+    pub preferences_status_bar_show_mode_switch: String,
 }
 
 /// Partial string set used by JSON language packs.
@@ -490,6 +502,12 @@ struct I18nStringsDe {
     status_bar_mode_source: Option<String>,
     status_bar_mode_rendered: Option<String>,
     status_bar_word_count_suffix: Option<String>,
+    preferences_nav_status_bar: Option<String>,
+    preferences_status_bar_enabled: Option<String>,
+    preferences_status_bar_show_word_count: Option<String>,
+    preferences_status_bar_show_cursor_position: Option<String>,
+    preferences_status_bar_show_sidebar_toggle: Option<String>,
+    preferences_status_bar_show_mode_switch: Option<String>,
 }
 
 const I18N_STRING_KEYS: &[&str] = &[
@@ -669,6 +687,12 @@ const I18N_STRING_KEYS: &[&str] = &[
     "status_bar_mode_source",
     "status_bar_mode_rendered",
     "status_bar_word_count_suffix",
+    "preferences_nav_status_bar",
+    "preferences_status_bar_enabled",
+    "preferences_status_bar_show_word_count",
+    "preferences_status_bar_show_cursor_position",
+    "preferences_status_bar_show_sidebar_toggle",
+    "preferences_status_bar_show_mode_switch",
 ];
 
 impl I18nStringsDe {
@@ -1146,6 +1170,24 @@ impl I18nStringsDe {
             status_bar_word_count_suffix: self
                 .status_bar_word_count_suffix
                 .unwrap_or(defaults.status_bar_word_count_suffix),
+            preferences_nav_status_bar: self
+                .preferences_nav_status_bar
+                .unwrap_or(defaults.preferences_nav_status_bar),
+            preferences_status_bar_enabled: self
+                .preferences_status_bar_enabled
+                .unwrap_or(defaults.preferences_status_bar_enabled),
+            preferences_status_bar_show_word_count: self
+                .preferences_status_bar_show_word_count
+                .unwrap_or(defaults.preferences_status_bar_show_word_count),
+            preferences_status_bar_show_cursor_position: self
+                .preferences_status_bar_show_cursor_position
+                .unwrap_or(defaults.preferences_status_bar_show_cursor_position),
+            preferences_status_bar_show_sidebar_toggle: self
+                .preferences_status_bar_show_sidebar_toggle
+                .unwrap_or(defaults.preferences_status_bar_show_sidebar_toggle),
+            preferences_status_bar_show_mode_switch: self
+                .preferences_status_bar_show_mode_switch
+                .unwrap_or(defaults.preferences_status_bar_show_mode_switch),
         }
     }
 }
@@ -1334,7 +1376,7 @@ impl I18nStrings {
             image_loading_without_alt: "正在加载图片...".into(),
             image_loading_with_alt_template: "正在加载 {alt}".into(),
             code_language_placeholder: "语言".into(),
-            status_bar_files: "文件".into(),
+            status_bar_files: "侧边栏".into(),
             status_bar_mode_source: "源码".into(),
             status_bar_mode_rendered: "渲染".into(),
             status_bar_word_count_suffix: "字".into(),
@@ -1342,6 +1384,12 @@ impl I18nStrings {
         };
         strings.image_paste_failed_title = "图片粘贴失败".into();
         strings.preferences_nav_image = "图像".into();
+        strings.preferences_nav_status_bar = "状态栏".into();
+        strings.preferences_status_bar_enabled = "显示状态栏".into();
+        strings.preferences_status_bar_show_word_count = "字数统计".into();
+        strings.preferences_status_bar_show_cursor_position = "光标位置".into();
+        strings.preferences_status_bar_show_sidebar_toggle = "侧边栏".into();
+        strings.preferences_status_bar_show_mode_switch = "模式切换".into();
         strings.preferences_image_insert_behavior = "插入图片时...".into();
         strings.preferences_image_paste_none = "无特殊操作".into();
         strings.preferences_image_paste_copy_to_document_folder = "复制图片到 ./ 文件夹".into();
@@ -1543,10 +1591,16 @@ impl I18nStrings {
             image_loading_without_alt: "Loading image...".into(),
             image_loading_with_alt_template: "Loading {alt}".into(),
             code_language_placeholder: "language".into(),
-            status_bar_files: "Files".into(),
+            status_bar_files: "Sidebar".into(),
             status_bar_mode_source: "Source".into(),
             status_bar_mode_rendered: "Rendered".into(),
             status_bar_word_count_suffix: "words".into(),
+            preferences_nav_status_bar: "Status Bar".into(),
+            preferences_status_bar_enabled: "Show Status Bar".into(),
+            preferences_status_bar_show_word_count: "Word Count".into(),
+            preferences_status_bar_show_cursor_position: "Cursor Position".into(),
+            preferences_status_bar_show_sidebar_toggle: "Sidebar Toggle".into(),
+            preferences_status_bar_show_mode_switch: "Mode Switch".into(),
         }
     }
 

--- a/src/theme/theme.rs
+++ b/src/theme/theme.rs
@@ -226,6 +226,14 @@ pub struct ThemeColors {
     pub dialog_danger_button_hover: Hsla,
     /// Danger button text colour.
     pub dialog_danger_button_text: Hsla,
+    /// Background of the editor status bar.
+    pub status_bar_background: Hsla,
+    /// Primary text colour in the status bar.
+    pub status_bar_text: Hsla,
+    /// Dimmed/secondary text colour in the status bar.
+    pub status_bar_text_dim: Hsla,
+    /// Hover background for clickable status bar items.
+    pub status_bar_button_hover: Hsla,
 }
 
 /// All configurable dimensions (paddings, gaps, sizes) for the editor UI.
@@ -451,6 +459,14 @@ pub struct ThemeDimensions {
     pub view_mode_toggle_border_width: f32,
     /// Text size of the view-mode toggle.
     pub view_mode_toggle_text_size: f32,
+    /// Height of the status bar.
+    pub status_bar_height: f32,
+    /// Horizontal padding inside the status bar.
+    pub status_bar_padding_x: f32,
+    /// Gap between items in the status bar.
+    pub status_bar_item_gap: f32,
+    /// Font size for status bar text.
+    pub status_bar_text_size: f32,
 }
 
 /// All configurable typography settings (font sizes, weights, line heights).
@@ -595,6 +611,10 @@ struct ThemeColorsDe {
     dialog_danger_button_bg: Hsla,
     dialog_danger_button_hover: Hsla,
     dialog_danger_button_text: Hsla,
+    status_bar_background: Option<Hsla>,
+    status_bar_text: Option<Hsla>,
+    status_bar_text_dim: Option<Hsla>,
+    status_bar_button_hover: Option<Hsla>,
 }
 
 impl<'de> Deserialize<'de> for ThemeColors {
@@ -793,6 +813,18 @@ impl<'de> Deserialize<'de> for ThemeColors {
             dialog_danger_button_bg: raw.dialog_danger_button_bg,
             dialog_danger_button_hover: raw.dialog_danger_button_hover,
             dialog_danger_button_text: raw.dialog_danger_button_text,
+            status_bar_background: raw
+                .status_bar_background
+                .unwrap_or_else(|| Hsla::from(rgba(0x1c1c1fff))),
+            status_bar_text: raw
+                .status_bar_text
+                .unwrap_or_else(|| Hsla::from(rgba(0xd4d4d8cc))),
+            status_bar_text_dim: raw
+                .status_bar_text_dim
+                .unwrap_or_else(|| Hsla::from(rgba(0x71717aff))),
+            status_bar_button_hover: raw
+                .status_bar_button_hover
+                .unwrap_or_else(|| Hsla::from(rgba(0x3f3f46ff))),
         })
     }
 }
@@ -910,6 +942,10 @@ struct ThemeDimensionsDe {
     view_mode_toggle_radius: Option<f32>,
     view_mode_toggle_border_width: Option<f32>,
     view_mode_toggle_text_size: Option<f32>,
+    status_bar_height: Option<f32>,
+    status_bar_padding_x: Option<f32>,
+    status_bar_item_gap: Option<f32>,
+    status_bar_text_size: Option<f32>,
 }
 
 impl<'de> Deserialize<'de> for ThemeDimensions {
@@ -1033,6 +1069,10 @@ impl<'de> Deserialize<'de> for ThemeDimensions {
             view_mode_toggle_radius: raw.view_mode_toggle_radius.unwrap_or(999.0),
             view_mode_toggle_border_width: raw.view_mode_toggle_border_width.unwrap_or(1.0),
             view_mode_toggle_text_size: raw.view_mode_toggle_text_size.unwrap_or(11.0),
+            status_bar_height: raw.status_bar_height.unwrap_or(28.0),
+            status_bar_padding_x: raw.status_bar_padding_x.unwrap_or(12.0),
+            status_bar_item_gap: raw.status_bar_item_gap.unwrap_or(12.0),
+            status_bar_text_size: raw.status_bar_text_size.unwrap_or(11.0),
         })
     }
 }
@@ -1143,6 +1183,10 @@ impl Theme {
                 dialog_danger_button_bg: Hsla::from(rgba(0xef4444ff)),
                 dialog_danger_button_hover: Hsla::from(rgba(0xdc2626ff)),
                 dialog_danger_button_text: Hsla::from(rgba(0xfef2f2ff)),
+                status_bar_background: Hsla::from(rgba(0x1c1c1fff)),
+                status_bar_text: Hsla::from(rgba(0xd4d4d8cc)),
+                status_bar_text_dim: Hsla::from(rgba(0x71717aff)),
+                status_bar_button_hover: Hsla::from(rgba(0x3f3f46ff)),
             },
             dimensions: ThemeDimensions {
                 editor_padding: 24.0,
@@ -1255,6 +1299,10 @@ impl Theme {
                 view_mode_toggle_radius: 999.0,
                 view_mode_toggle_border_width: 1.0,
                 view_mode_toggle_text_size: 11.0,
+                status_bar_height: 28.0,
+                status_bar_padding_x: 12.0,
+                status_bar_item_gap: 12.0,
+                status_bar_text_size: 11.0,
             },
             typography: ThemeTypography {
                 text_size: 17.0,
@@ -1378,6 +1426,10 @@ impl Theme {
                 dialog_danger_button_bg: Hsla::from(rgba(0xdc2626ff)),
                 dialog_danger_button_hover: Hsla::from(rgba(0xb91c1cff)),
                 dialog_danger_button_text: Hsla::from(rgba(0xffffffff)),
+                status_bar_background: Hsla::from(rgba(0xe2e8f0ff)),
+                status_bar_text: Hsla::from(rgba(0x334155ff)),
+                status_bar_text_dim: Hsla::from(rgba(0x64748bff)),
+                status_bar_button_hover: Hsla::from(rgba(0xcbd5e1ff)),
             },
             dimensions: base.dimensions,
             typography: base.typography,


### PR DESCRIPTION
## Summary

- Adds a bottom status bar with sidebar toggle, view-mode switch, cursor position, word count, and custom-button support
- Adds a StatusBar preference page with per-component toggle switches
- Introduces a reusable Switch component with slide animation
- Adds theme tokens and i18n strings for all status bar elements

## Preview

### Editor

<img width="1350" height="900" alt="Editor" src="https://github.com/user-attachments/assets/d4144b59-76f0-4dad-a351-57946433c98e" />

### Preference

<img width="900" height="600" alt="Preference" src="https://github.com/user-attachments/assets/993b34d3-6b50-4952-8223-fc9235d7fbab" />

## Known limitations

- The custom_buttons array is parsed from config.toml and rendered as labels, but they are currently non-interactive. The action_id field is not wired to any action dispatch. This is intentional scoping for this PR. After Command Panel (like #35) completed, Custom buttons can reuse it as action dispatcher.
- No integration-level tests for the status bar render output or the Switch animation, while only unit tests for count_words.

Resolve: #46 