### PR TITLE
Add scrolling beyond last line and snappier block creation

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -118,6 +118,10 @@ pub struct Editor {
     scrollbar_hovered: bool,
     scrollbar_visible_until: Instant,
     scrollbar_fade_task: Option<Task<()>>,
+    /// Forces a repaint shortly after a pending scroll-into-view that could
+    /// not be satisfied yet (the target block has no measured bounds), so the
+    /// scroll lands on the next frame instead of waiting for the cursor blink.
+    scroll_recheck_task: Option<Task<()>>,
     scrollbar_drag: Option<ScrollbarDragSession>,
     undo_history: Vec<HistoryEntry>,
     redo_history: Vec<HistoryEntry>,
@@ -309,6 +313,7 @@ impl Editor {
             scrollbar_hovered: false,
             scrollbar_visible_until: Instant::now(),
             scrollbar_fade_task: None,
+            scroll_recheck_task: None,
             scrollbar_drag: None,
             undo_history: Vec::new(),
             redo_history: Vec::new(),

--- a/src/editor/render.rs
+++ b/src/editor/render.rs
@@ -2,7 +2,7 @@
 //! unsaved-changes overlay dialog, custom scrollbar, and deferred
 //! operations (focus, scroll, save, window title).
 
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use gpui::*;
 
@@ -508,16 +508,30 @@ impl Editor {
         let has_bounds = self.ensure_focused_caret_visible(window, cx);
         if self.pending_scroll_recheck_after_layout {
             self.pending_scroll_recheck_after_layout = false;
-            cx.notify();
+            self.schedule_scroll_recheck(cx);
             return;
         }
 
         if !has_bounds {
-            cx.notify();
+            self.schedule_scroll_recheck(cx);
             return;
         }
 
         self.pending_scroll_active_block_into_view = false;
+        self.scroll_recheck_task = None;
+    }
+
+    /// Requests a repaint one frame out so a still-pending scroll-into-view can
+    /// retry once the target block has been laid out. `cx.notify()` is swallowed
+    /// when called from within `render`, so without this the retry would wait
+    /// for the next external notify (e.g. the cursor blink, ~0.5s later).
+    fn schedule_scroll_recheck(&mut self, cx: &mut Context<Self>) {
+        self.scroll_recheck_task = Some(cx.spawn(async move |this: WeakEntity<Self>, cx| {
+            cx.background_executor()
+                .timer(Duration::from_millis(16))
+                .await;
+            let _ = this.update(cx, |_this, cx| cx.notify());
+        }));
     }
 
     fn sync_pending_save(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -1540,6 +1554,9 @@ impl Render for Editor {
         let scroll_trigger_padding = (d.block_min_height * 0.75).max(16.0);
         let max_scroll_y = f32::from(self.scroll_handle.max_offset().height.max(px(0.0)));
         let viewport_height = f32::from(viewport_bounds.size.height.max(px(1.0)));
+        // Extra room below the last block so the lowest line can be scrolled up
+        // to the viewport center instead of being pinned to the bottom edge.
+        let scroll_beyond_bottom = viewport_height * 0.5;
         let viewport_width = f32::from(viewport_bounds.size.width.max(px(1.0)));
         let has_overflow = max_scroll_y > 0.5;
 
@@ -1771,7 +1788,9 @@ impl Render for Editor {
             .on_mouse_up_out(MouseButton::Left, cx.listener(Self::on_editor_mouse_up))
             .on_scroll_wheel(cx.listener(Self::on_editor_scroll_wheel))
             .p(px(d.editor_padding))
-            .pb(px(d.editor_padding + scroll_trigger_padding))
+            .pb(px(d.editor_padding
+                + scroll_trigger_padding
+                + scroll_beyond_bottom))
             .children(block_rows);
         let scroll_content = if self.view_mode == super::ViewMode::Rendered {
             scroll_content.on_mouse_down(


### PR DESCRIPTION
This PR fixes #94, as well as faster block-creation view-snapping, two vertical-scrolling improvements.

All changes are confined to the existing parser/runtime model. No new dependencies.

Unit tests have been added for the following.

### 1. Allow scrolling half a viewport past the last block

The document could not be scrolled below the lowest block, so in any document long enough to fill the viewport the caret stayed pinned near the bottom edge while typing, which isn't an ideal experience.

**Fix:** I added half the viewport height to the scroll column's bottom padding (`editor_padding + scroll_trigger_padding + viewport_height * 0.5`). This works for every scroll method, and only produces overflow once content passes the halfway point of the viewport height, so short documents stay non-scrollable.

### 2. Reveal a freshly created block immediately

Pressing Enter near the bottom of the viewport created a block that was partly clipped, and the view only snapped to reveal it about half a second later.

**Cause:** The pending scroll-into-view retries itself with `cx.notify()`, but that call runs inside the editor's `render` pass, where it is swallowed and schedules no fresh frame. With no further input, the next repaint came from the cursor-blink task ~0.5s later, so the retry only ran then.

**Fix:** When a pending scroll-into-view cannot be satisfied yet, schedule a one-shot repaint a frame later from off the render pass (a short timer task that then calls `notify`). The retry runs once the new block has been laid out and its bounds are known. This is handled in the shared scroll pass, so it covers every block-creating Enter path (new line, quote break, etc) at the root.

Bottom-viewport block creation feels much snappier now.