### PR TITLE
Performance increase for long documents

### DIFF
--- a/benches/render_loop.rs
+++ b/benches/render_loop.rs
@@ -174,6 +174,32 @@ fn simulate_projection_build(fragments: &[MockFragment]) -> Option<(usize, Vec<u
     any_expanded.then_some((display_cursor, clean_to_display))
 }
 
+/// Pick the run of rows whose extent intersects the viewport band, from each
+/// row's content-space top. Mirrors the shape of `Editor::rendered_window`.
+fn windowed_run(tops: &[f32], row_height: f32, band_top: f32, band_bottom: f32) -> (usize, usize) {
+    let n = tops.len();
+    let start = tops
+        .iter()
+        .position(|&top| top + row_height >= band_top)
+        .unwrap_or(n);
+    let end = tops
+        .iter()
+        .rposition(|&top| top <= band_bottom)
+        .map(|i| i + 1)
+        .unwrap_or(0);
+    (start, end.max(start))
+}
+
+/// Stand-in for the per-row element construction skipped when a row is culled:
+/// a small allocation plus arithmetic, black-boxed so it is not optimized away.
+fn simulated_row_build(seed: usize) -> usize {
+    let mut buf = Vec::with_capacity(8);
+    for k in 0..8 {
+        buf.push(black_box(seed.wrapping_mul(31).wrapping_add(k)));
+    }
+    black_box(buf.iter().sum())
+}
+
 fn render_loop(c: &mut Criterion) {
     // Per-block fixtures.
     let theme_owned = MockTheme::new();
@@ -190,7 +216,7 @@ fn render_loop(c: &mut Criterion) {
     let epoch = Instant::now();
 
     let mut group = c.benchmark_group("render loop (per frame)");
-    for &n_blocks in &[50usize, 200usize] {
+    for &n_blocks in &[50usize, 200usize, 1_000usize, 5_000usize] {
         group.bench_with_input(
             BenchmarkId::new("baseline", n_blocks),
             &n_blocks,
@@ -235,6 +261,77 @@ fn render_loop(c: &mut Criterion) {
         );
     }
     group.finish();
+
+    // Viewport culling: per-row build work for every row vs only the on-screen
+    // window. The saving grows with document length.
+    let mut culling = c.benchmark_group("viewport culling (per frame)");
+    for &n_blocks in &[1_000usize, 5_000usize, 15_000usize, 30_000usize] {
+        let row_height = 50.0f32;
+        let tops: Vec<f32> = (0..n_blocks).map(|i| i as f32 * row_height).collect();
+        // A ~800px viewport band parked in the middle of the document.
+        let band_top = (n_blocks as f32 * row_height) * 0.5;
+        let band_bottom = band_top + 800.0;
+
+        culling.bench_with_input(
+            BenchmarkId::new("baseline (all rows)", n_blocks),
+            &n_blocks,
+            |b, &n_blocks| {
+                b.iter(|| {
+                    let mut acc = 0usize;
+                    for i in 0..n_blocks {
+                        acc += simulated_row_build(i);
+                    }
+                    black_box(acc);
+                });
+            },
+        );
+        culling.bench_with_input(
+            BenchmarkId::new("current (windowed)", n_blocks),
+            &n_blocks,
+            |b, &_n_blocks| {
+                b.iter(|| {
+                    let (start, end) =
+                        windowed_run(black_box(&tops), row_height, band_top, band_bottom);
+                    let mut acc = 0usize;
+                    for i in start..end {
+                        acc += simulated_row_build(i);
+                    }
+                    black_box(acc);
+                });
+            },
+        );
+
+        // Windowed path with ~1-in-20 unmeasured rows (unfocused math/mermaid),
+        // to check culling stays active when estimates are mixed in.
+        let measured: Vec<bool> = (0..n_blocks).map(|i| i % 20 != 0).collect();
+        culling.bench_with_input(
+            BenchmarkId::new("current (windowed, mixed structures)", n_blocks),
+            &n_blocks,
+            |b, &n_blocks| {
+                b.iter(|| {
+                    let mut tops_filled = vec![0.0f32; n_blocks];
+                    let mut cursor = 0.0f32;
+                    for i in 0..n_blocks {
+                        if measured[i] {
+                            tops_filled[i] = i as f32 * row_height;
+                            cursor = tops_filled[i] + row_height;
+                        } else {
+                            tops_filled[i] = cursor;
+                            cursor += row_height;
+                        }
+                    }
+                    let (start, end) =
+                        windowed_run(black_box(&tops_filled), row_height, band_top, band_bottom);
+                    let mut acc = 0usize;
+                    for i in start..end {
+                        acc += simulated_row_build(i);
+                    }
+                    black_box(acc);
+                });
+            },
+        );
+    }
+    culling.finish();
 }
 
 criterion_group!(benches, render_loop);

--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -80,6 +80,17 @@ pub struct Editor {
     file_path: Option<PathBuf>,
     scroll_handle: ScrollHandle,
     last_scroll_viewport_size: Option<Size<Pixels>>,
+    /// Last frame's visible block ids, to detect structural edits so the height
+    /// cache is refreshed only when the row/block mapping is unchanged.
+    prev_visible_block_ids: Vec<EntityId>,
+    /// Per-row footprint (height plus trailing gap), keyed by the row's first
+    /// block. Scroll-invariant, unlike raw painted positions, so windowing from
+    /// their running sum stays correct as the document scrolls. Filled as rows
+    /// paint; unknown rows use a minimum-height estimate.
+    row_stride_cache: HashMap<EntityId, f32>,
+    /// Row range mounted last frame; only those rows shared one scroll offset, so
+    /// their adjacent-top differences are valid footprints for the cache.
+    prev_render_window: Option<(usize, usize)>,
     close_guard_installed: bool,
     show_unsaved_changes_dialog: bool,
     /// When true, the window will close after the next successful save.
@@ -159,6 +170,16 @@ struct ScrollbarGeometry {
     thumb_height: f32,
     thumb_top: f32,
     max_scroll_y: f32,
+}
+
+/// Windowing result: the run of rows to mount, plus the top/bottom spacer
+/// heights standing in for the culled rows.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct RenderWindow {
+    run_start: usize,
+    run_end: usize,
+    top_h: f32,
+    bottom_h: f32,
 }
 
 /// Active drag session for the custom scrollbar thumb.
@@ -285,6 +306,9 @@ impl Editor {
             file_path,
             scroll_handle: ScrollHandle::new(),
             last_scroll_viewport_size: None,
+            prev_visible_block_ids: Vec::new(),
+            row_stride_cache: HashMap::new(),
+            prev_render_window: None,
             close_guard_installed: false,
             show_unsaved_changes_dialog: false,
             pending_close_after_save: false,

--- a/src/editor/render.rs
+++ b/src/editor/render.rs
@@ -9,12 +9,16 @@ use gpui::*;
 use super::{Editor, InfoDialogKind, workspace::workspace_panel_width_for_viewport};
 use crate::app_menu::dispatch_menu_action_for_editor;
 use crate::components::CalloutVariant;
-use crate::components::{AddLanguageConfig, AddThemeConfig, Block, BlockKind, NoRecentFiles};
+use crate::components::{AddLanguageConfig, AddThemeConfig, Block, NoRecentFiles};
 use crate::i18n::{I18nManager, I18nStrings};
 use crate::theme::{Theme, ThemeDimensions, ThemeManager};
 use crate::window_chrome::{custom_titlebar_height, render_custom_titlebar};
 
 pub(crate) const ABOUT_GITHUB_URL: &str = "https://github.com/manyougz/velotype";
+
+/// Rows within this many pixels of the viewport stay mounted, so a fast flick
+/// paints them before they scroll in instead of showing a blank edge.
+const RENDER_OVERDRAW_PX: f32 = 800.0;
 
 pub(crate) fn open_about_github_url(cx: &mut App) {
     cx.open_url(ABOUT_GITHUB_URL);
@@ -460,34 +464,6 @@ impl Editor {
         true
     }
 
-    fn should_use_item_scroll(&self, window: &Window, cx: &App) -> bool {
-        if self.view_mode == super::ViewMode::Source {
-            return false;
-        }
-
-        let Some(focused_id) = self.focused_edit_target_entity_id(window, cx) else {
-            return true;
-        };
-        if self.table_cell_binding(focused_id).is_some() {
-            return false;
-        }
-        let Some(focused_block) = self.document.block_entity_by_id(focused_id) else {
-            return true;
-        };
-        if focused_block.read_with(cx, |block, _cx| {
-            matches!(block.kind(), BlockKind::MathBlock | BlockKind::MermaidBlock)
-        }) {
-            return false;
-        }
-
-        let Some(block_bounds) = focused_block.read_with(cx, |block, _cx| block.last_bounds) else {
-            return true;
-        };
-
-        let viewport = self.scroll_handle.bounds();
-        block_bounds.size.height <= viewport.size.height
-    }
-
     fn apply_pending_scroll_into_view(&mut self, window: &Window, cx: &mut Context<Self>) {
         if self.scrollbar_drag.is_some() {
             return;
@@ -497,14 +473,8 @@ impl Editor {
             return;
         }
 
-        let use_item_scroll = self.should_use_item_scroll(window, cx);
-        if use_item_scroll
-            && let Some(focused_id) = self.focused_edit_target_entity_id(window, cx)
-            && let Some(focused_idx) = self.document.visible_index_for_entity_id(focused_id)
-        {
-            self.scroll_handle.scroll_to_item(focused_idx);
-        }
-
+        // scroll_to_item indexed children by position, which the spacers break;
+        // the focused block is always mounted, so pixel math on its bounds works.
         let has_bounds = self.ensure_focused_caret_visible(window, cx);
         if self.pending_scroll_recheck_after_layout {
             self.pending_scroll_recheck_after_layout = false;
@@ -1582,7 +1552,12 @@ impl Render for Editor {
                 .read_with(cx, |block, _cx| RenderedRowSpacingInfo::from_block(block))
         };
         let mut previous_row_spacing = None;
-        let mut block_rows = Vec::new();
+        // One entry per render row; off-screen rows are dropped after windowing.
+        let mut row_elements: Vec<AnyElement> = Vec::new();
+        let mut row_starts: Vec<usize> = Vec::new();
+        // Each row's leading `mt` gap; the top spacer subtracts the first mounted
+        // row's, since that row re-applies it.
+        let mut row_top_gaps: Vec<f32> = Vec::new();
         let mut index = 0usize;
         while index < visible_blocks.len() {
             let first_visible = visible_blocks[index].clone();
@@ -1677,7 +1652,9 @@ impl Render for Editor {
                 }
 
                 let (accent, background) = callout_colors(callout_variant, &theme);
-                block_rows.push(
+                row_starts.push(index);
+                row_top_gaps.push(top_gap);
+                row_elements.push(
                     div()
                         .w(px(centered_width))
                         .max_w(relative(1.0))
@@ -1731,7 +1708,9 @@ impl Render for Editor {
                     group_end += 1;
                 }
 
-                block_rows.push(
+                row_starts.push(index);
+                row_top_gaps.push(top_gap);
+                row_elements.push(
                     div()
                         .w(px(centered_width))
                         .max_w(relative(1.0))
@@ -1763,9 +1742,131 @@ impl Render for Editor {
             } else {
                 row
             };
-            block_rows.push(row.into_any_element());
+            row_starts.push(index);
+            row_top_gaps.push(top_gap);
+            row_elements.push(row.into_any_element());
             previous_row_spacing = Some(first_spacing);
             index += 1;
+        }
+
+        // The focused row is always kept mounted so its caret is not blurred; a
+        // table cell maps to its containing table block's row.
+        let focus_row = self
+            .focused_edit_target_entity_id(window, cx)
+            .and_then(|id| {
+                self.document.visible_index_for_entity_id(id).or_else(|| {
+                    self.table_cell_binding(id).and_then(|binding| {
+                        self.document
+                            .visible_index_for_entity_id(binding.table_block.entity_id())
+                    })
+                })
+            })
+            .map(|visible_index| {
+                row_starts
+                    .partition_point(|&start| start <= visible_index)
+                    .saturating_sub(1)
+            });
+
+        // A row's first block keys its cached height; its painted top (from last
+        // frame) feeds the footprints below.
+        let row_first_ids: Vec<EntityId> = row_starts
+            .iter()
+            .map(|&start| visible_blocks[start].entity.entity_id())
+            .collect();
+        let row_tops: Vec<Option<f32>> = row_starts
+            .iter()
+            .map(|&start| {
+                visible_blocks[start]
+                    .entity
+                    .read_with(cx, |block, _cx| block.last_bounds)
+                    .map(|bounds| f32::from(bounds.top()))
+            })
+            .collect();
+
+        // On a structural edit the row indices no longer match last frame, so the
+        // cache refresh below is skipped; its block-keyed entries still hold.
+        let structural_change = visible_blocks.len() != self.prev_visible_block_ids.len()
+            || visible_blocks
+                .iter()
+                .zip(&self.prev_visible_block_ids)
+                .any(|(visible, prev)| visible.entity.entity_id() != *prev);
+        if structural_change {
+            self.prev_visible_block_ids = visible_blocks
+                .iter()
+                .map(|v| v.entity.entity_id())
+                .collect();
+        }
+
+        // Rows mounted together last frame shared one scroll offset, so their
+        // adjacent painted-top differences are scroll-free heights. Caching those,
+        // not raw positions, is what keeps the window stable while scrolling.
+        if !structural_change {
+            if let Some((prev_start, prev_end)) = self.prev_render_window {
+                let prev_end = prev_end.min(row_first_ids.len());
+                for row in prev_start..prev_end.saturating_sub(1) {
+                    if let (Some(top), Some(next_top)) = (row_tops[row], row_tops[row + 1]) {
+                        let stride = next_top - top;
+                        if stride > 0.0 && stride.is_finite() {
+                            self.row_stride_cache.insert(row_first_ids[row], stride);
+                        }
+                    }
+                }
+            }
+        }
+
+        // Unmeasured rows use the minimum block height: a lower bound, so the
+        // window over-mounts rather than ever landing on a spacer.
+        let estimate = d.block_min_height.max(1.0);
+        let strides: Vec<f32> = row_first_ids
+            .iter()
+            .map(|id| self.row_stride_cache.get(id).copied().unwrap_or(estimate))
+            .collect();
+
+        // Bound the cache against block churn, only when it outgrows the live rows.
+        if self.row_stride_cache.len() > row_first_ids.len().saturating_mul(2) {
+            let live: std::collections::HashSet<EntityId> = row_first_ids.iter().copied().collect();
+            self.row_stride_cache.retain(|id, _| live.contains(id));
+        }
+
+        let render_window = Self::rendered_window(
+            &strides,
+            current_scroll_y,
+            viewport_height,
+            RENDER_OVERDRAW_PX,
+            focus_row,
+        );
+        self.prev_render_window = Some((render_window.run_start, render_window.run_end));
+
+        // The first mounted row re-applies its `mt`, so drop it from the top
+        // spacer to avoid shifting content down by a gap.
+        let top_h = match row_top_gaps.get(render_window.run_start) {
+            Some(gap) => (render_window.top_h - gap).max(0.0),
+            None => render_window.top_h,
+        };
+        let mut block_rows: Vec<AnyElement> =
+            Vec::with_capacity(render_window.run_end - render_window.run_start + 2);
+        if top_h > 0.5 {
+            block_rows.push(
+                div()
+                    .w_full()
+                    .flex_shrink_0()
+                    .h(px(top_h))
+                    .into_any_element(),
+            );
+        }
+        for (row_index, element) in row_elements.into_iter().enumerate() {
+            if row_index >= render_window.run_start && row_index < render_window.run_end {
+                block_rows.push(element);
+            }
+        }
+        if render_window.bottom_h > 0.5 {
+            block_rows.push(
+                div()
+                    .w_full()
+                    .flex_shrink_0()
+                    .h(px(render_window.bottom_h))
+                    .into_any_element(),
+            );
         }
 
         let scroll_content = div()

--- a/src/editor/tests.rs
+++ b/src/editor/tests.rs
@@ -110,6 +110,109 @@ fn scrollbar_offset_mapping_clamps_to_track_bounds() {
     );
 }
 
+/// Equal-height rows as per-row footprints, the input `rendered_window` takes.
+fn uniform_strides(count: usize, height: f32) -> Vec<f32> {
+    vec![height; count]
+}
+
+#[test]
+fn rendered_window_culls_offscreen_rows() {
+    // 100 rows of 50px (total 5000). Scroll 2000, viewport 400 -> band [2000, 2400].
+    let strides = uniform_strides(100, 50.0);
+    let window = Editor::rendered_window(&strides, 2000.0, 400.0, 0.0, None);
+
+    // Row i spans [50i, 50i+50). bottom>=2000 -> i>=39; top<=2400 -> i<=48.
+    assert_eq!(window.run_start, 39);
+    assert_eq!(window.run_end, 49);
+    assert!((window.top_h - 1950.0).abs() < 0.01);
+    assert!((window.bottom_h - 2550.0).abs() < 0.01);
+}
+
+#[test]
+fn rendered_window_keeps_focus_row_mounted() {
+    let strides = uniform_strides(100, 50.0);
+    // Viewport at the top, caret parked far below at row 80.
+    let window = Editor::rendered_window(&strides, 0.0, 400.0, 0.0, Some(80));
+
+    assert_eq!(window.run_start, 0);
+    assert_eq!(window.run_end, 81);
+}
+
+#[test]
+fn rendered_window_tracks_current_scroll_offset() {
+    // Scrolling by one row's height shifts the mounted run by exactly one row.
+    let strides = uniform_strides(100, 50.0);
+
+    let low = Editor::rendered_window(&strides, 2000.0, 400.0, 0.0, None);
+    let high = Editor::rendered_window(&strides, 2050.0, 400.0, 0.0, None);
+
+    assert_eq!(low.run_start, 39);
+    assert_eq!(low.run_end, 49);
+    assert_eq!(high.run_start, low.run_start + 1);
+    assert_eq!(high.run_end, low.run_end + 1);
+}
+
+#[test]
+fn rendered_window_has_no_spacer_at_document_edges() {
+    let strides = uniform_strides(50, 40.0); // total 2000
+
+    let at_top = Editor::rendered_window(&strides, 0.0, 400.0, 0.0, None);
+    assert_eq!(at_top.run_start, 0);
+    assert_eq!(at_top.top_h, 0.0);
+    assert!(at_top.bottom_h > 0.0);
+
+    let at_bottom = Editor::rendered_window(&strides, 1600.0, 400.0, 0.0, None);
+    assert_eq!(at_bottom.run_end, 50);
+    assert_eq!(at_bottom.bottom_h, 0.0);
+    assert!(at_bottom.top_h > 0.0);
+}
+
+#[test]
+fn rendered_window_preserves_total_height() {
+    let strides = uniform_strides(200, 37.0);
+    let total: f32 = strides.iter().sum();
+
+    for &(scroll_y, viewport_height, focus) in &[
+        (0.0f32, 500.0f32, None),
+        (3000.0, 500.0, None),
+        (37.0 * 150.0, 37.0 * 5.0, Some(10usize)),
+    ] {
+        let window = Editor::rendered_window(&strides, scroll_y, viewport_height, 200.0, focus);
+        let rendered: f32 = strides[window.run_start..window.run_end].iter().sum();
+        assert!(
+            (window.top_h + rendered + window.bottom_h - total).abs() < 0.01,
+            "height invariant broken at scroll {scroll_y}"
+        );
+    }
+}
+
+#[test]
+fn rendered_window_estimated_row_keeps_culling_active() {
+    // Row 60 is an estimated (unmeasured) row; it must not disable culling.
+    let mut strides = uniform_strides(100, 50.0);
+    strides[60] = 20.0;
+
+    let window = Editor::rendered_window(&strides, 0.0, 400.0, 0.0, None);
+    assert_eq!(window.run_start, 0);
+    assert!(
+        window.run_end < strides.len(),
+        "a single estimated row must not disable culling"
+    );
+}
+
+#[test]
+fn rendered_window_all_estimated_windows_near_top() {
+    // Cold start: all rows estimated. At the top the window still covers the
+    // first rows, so the viewport is never blank while heights are learned.
+    let strides = uniform_strides(500, 20.0);
+
+    let window = Editor::rendered_window(&strides, 0.0, 400.0, 0.0, None);
+    assert_eq!(window.run_start, 0);
+    assert!(window.run_end < strides.len());
+    // A viewport-plus-band worth of rows, not the whole document.
+    assert!(window.run_end >= 20);
+}
+
 #[test]
 fn about_dialog_body_lines_include_repository_and_star_message() {
     let strings = I18nStrings::zh_cn();

--- a/src/editor/window_state.rs
+++ b/src/editor/window_state.rs
@@ -48,6 +48,83 @@ impl Editor {
         max_scroll_y * progress
     }
 
+    /// Picks the contiguous run of rows to mount; the culled runs become two
+    /// spacers and the focused row stays mounted. `strides[i]` is row `i`'s
+    /// footprint (height plus trailing gap); being scroll-invariant, their running
+    /// sum places each row against a band from the current scroll offset.
+    /// Unmeasured rows use a lower-bound estimate, so the window never lands on a
+    /// spacer. Pure, so it is unit-tested headlessly.
+    pub(super) fn rendered_window(
+        strides: &[f32],
+        scroll_y: f32,
+        viewport_height: f32,
+        overdraw: f32,
+        focus_row: Option<usize>,
+    ) -> RenderWindow {
+        let n = strides.len();
+        if n == 0 {
+            return RenderWindow {
+                run_start: 0,
+                run_end: 0,
+                top_h: 0.0,
+                bottom_h: 0.0,
+            };
+        }
+
+        let band_top = scroll_y - overdraw;
+        let band_bottom = scroll_y + viewport_height + overdraw;
+
+        let mut run_start = n;
+        let mut run_end = 0usize;
+        let mut top_of_start = 0.0f32;
+        let mut bottom_of_end = 0.0f32;
+        let mut cursor = 0.0f32;
+        for (index, &stride) in strides.iter().enumerate() {
+            let top = cursor;
+            let bottom = cursor + stride.max(0.0);
+            if bottom >= band_top && top <= band_bottom {
+                if index < run_start {
+                    run_start = index;
+                    top_of_start = top;
+                }
+                run_end = index + 1;
+                bottom_of_end = bottom;
+            }
+            cursor = bottom;
+        }
+        let total = cursor;
+
+        // Nothing hit the band (float edge, or estimate short of scroll): mount
+        // the last row so the viewport never lands on a spacer.
+        if run_start >= run_end {
+            run_start = n - 1;
+            run_end = n;
+            top_of_start = total - strides[n - 1].max(0.0);
+            bottom_of_end = total;
+        }
+
+        // Keep the focused row mounted; GPUI blurs an unmounted caret. Reaching a
+        // far focus row widens the run, but autoscroll makes that rare.
+        if let Some(focus_row) = focus_row {
+            let focus_row = focus_row.min(n - 1);
+            if focus_row < run_start {
+                run_start = focus_row;
+                top_of_start = strides[..focus_row].iter().map(|s| s.max(0.0)).sum();
+            }
+            if focus_row + 1 > run_end {
+                run_end = focus_row + 1;
+                bottom_of_end = strides[..=focus_row].iter().map(|s| s.max(0.0)).sum();
+            }
+        }
+
+        RenderWindow {
+            run_start,
+            run_end,
+            top_h: top_of_start.max(0.0),
+            bottom_h: (total - bottom_of_end).max(0.0),
+        }
+    }
+
     /// Linearly interpolates the editor content width ratio based on viewport
     /// width. The column stays full-width until `centered_shrink_start`, then
     /// shrinks to `centered_min_ratio` at `centered_shrink_end`.


### PR DESCRIPTION

# Performance increase for long documents

This PR effectively triples the performance of Velotype with longer documents. Open issues relevant to this include #60, #61, #90.

All changes are confined to the existing parser/runtime model. No new dependencies. No changes to the scrollbar or source mode.

Unit tests have been added for all of the following.

## Problem

Long documents (thousands of blocks) are sluggish because the editor paints every block every frame, on-screen or not. `Editor::render` embeds every visible block as a child of a single `overflow_y_scroll` container. A plain scroll container does not cull, so GPUI paints all children, off-screen included. Per-frame cost scales with document length, which is heavy on long files. (This only impacts Rendered mode; Source mode is a single block with nothing to cull, has no performance issue.)

## Solution

Viewport culling is the answer. This fix windows the rendered-mode block column to the on-screen rows plus a small overdraw and replaces the off-screen runs with two height spacers. Which rows are on-screen is decided from a scroll-invariant per-row height cache, so the window stays correct as the document scrolls. This is intentionally a small-footprint, elegant solution. Source mode, the scroll API, the custom scrollbar, and drag-select are untouched.

## Details

The block-row loop still builds each row, but only the on-screen run plus overdraw plus the focused row is mounted. The culled runs above and below become two empty height spacers, so the scroll content height and the custom scrollbar stay correct.

The rows to mount are chosen by `rendered_window` from each row's content-space top. Those tops are a running sum of per-row footprints held in a small cache keyed by the row's first block. A footprint is the difference of two tops painted in the same frame, so it carries no scroll offset; summing footprints and comparing against a band taken from the current scroll offset selects the visible rows with no drift as the document scrolls (a surfaced issue that needed fixing).

Rows not yet measured fall back to the minimum block height, a lower bound that only ever over-mounts and never leaves the viewport on a spacer. That lets a structural edit keep culling instead of forcing a full-document frame. The focused row is always mounted so its caret and IME survive scrolling off-screen (another surfaced issue that needed fixing); caret-into-view keeps the existing pixel math on the focused block's real bounds.

Special thanks to @hazuki-keatsu for sharing an idea that helped lead to a fix for the scrolling issue that surfaced.

## Results

The CPU load is almost halved (once the document reaches more substantial lengths).

The performance is roughly tripled...though this is hard to measure. Automated test results show it to be ~30x faster...but these are focused on the speed of the per-row work itself, and I find these to be very inaccurate to the actual total reality. In using the app myself during manual testing, I would say it's more like **~2-4x the performance**. This appears to apply evenly across the board (typing, scrolling, window dragging, etc).

I want to reiterate that this performance issue is tied to *blocks*, not *words*. After this fix, a real-world document should not hit significant trouble until above 100K words (a rough estimate, and admitting I only manual tested it on my Windows PC).

Velotype will still struggle with documents that are true behemoths, but this fix is good enough that the issue shouldn't arise again for the vast majority of users. Further gains would require substantial high-risk refactoring, and it was deemed not worthwhile per the app's identity (scratchpad, not a reader) and from past discussion with the repo owner.
<br>

## Automated test results (not real-world):

*These focus on the per-row work, inaccurate to the actual total reality.*

#### Speed of the per-row work

| Blocks      | All rows (no culling) | Windowed — text-only      | Windowed — mixed structures |
| ----------- | --------------------- | ------------------------- | --------------------------- |
| 1,000       | 20.7 µs               | 0.94 µs                   | 2.19 µs                     |
| 5,000       | 103.8 µs              | 3.01 µs                   | 9.18 µs                     |
| 50,000      | 1.047 ms              | 25.3 µs                   | 87.9 µs                     |
| **100,000** | **2.128 ms**          | **50.9 µs (≈42× faster)** | **177 µs (≈12× faster)**    |

#### CPU load

|                                              | Renders/sec | Before (no culling)                                        | After (culling)                                   |
| -------------------------------------------- | ----------- | ---------------------------------------------------------- | ------------------------------------------------- |
| **Scrolling**                                | ~60 target  | ~70 ms/frame → **one core pinned ~100%**, stuck at ~14 fps | ~0.15 ms/frame → **<1% of a core**, smooth 60 fps |
| **Idle, cursor blink** (post-throttle, ~2/s) | ~2          | ~70 ms × 2 ≈ **~14% of a core, doing nothing**             | negligible (~0.0004%)                             |

<br>
<br>

## Videos of manual testing
<br>


**Performance, v0.6.7 vs now:**

https://github.com/user-attachments/assets/3efdb67d-9e99-4020-abbc-3b1ca9e4ac9e

<br>
<br>

**Scrolling, showing the issue that arose during this viewport culling improvement (Old) vs post-fix (New):**


https://github.com/user-attachments/assets/49ed77ab-4f2a-4e91-9e1a-8faf1476b924


<br>

## Alternatives considered, decided against

- **`gpui::list`:** It culls natively, but it owns scrolling (forcing a migration of the scroll handle, the custom scrollbar, and the caret math), resets to the top on structural edits, and cannot hold focus for callout/footnote groups that render as one wrapper around several independently focused blocks. Too invasive and very risk-prone.
- **`gpui-component`:** Too heavy of an add by Velotype's standards. It would be a substantial new dependency including many things we don't use just for one virtualized-list behavior; not a worthwhile trade.
- **Windowing from raw painted positions:** A painted position bakes in the scroll offset from whenever the row was last on-screen, so off-screen rows carry a stale baseline and the window drifts: the viewport lands on a spacer and the mounted run jumps while typing.
- **Building only the visible rows:** Extracting the row-build body so off-screen rows are never constructed is a large refactor of the group-assembly code for a smaller win, since off-screen element construction is cheap next to the layout and text-shaping that this already culls...deemed not a worthwhile change.
<br>
<br>