### PR TITLE
fix(window): improve macOS titlebar behavior

### DIFF
--- a/src/window_chrome.rs
+++ b/src/window_chrome.rs
@@ -48,7 +48,7 @@ pub(crate) fn titlebar_options_for_target_os(
         title: Some(title),
         appears_transparent: matches!(target_os, "macos" | "windows"),
         traffic_light_position: if target_os == "macos" {
-            Some(point(px(14.0), px(16.0)))
+            Some(point(px(14.0), px(10.0)))
         } else {
             None
         },
@@ -133,6 +133,10 @@ pub(crate) fn custom_titlebar_height_for_target_os(
 }
 
 pub(crate) fn custom_titlebar_height(window: &Window, dimensions: &ThemeDimensions) -> f32 {
+    if cfg!(target_os = "macos") && window.is_fullscreen() {
+        return 0.0;
+    }
+
     custom_titlebar_height_for_target_os(
         std::env::consts::OS,
         window.window_decorations(),
@@ -168,6 +172,10 @@ pub(crate) fn render_custom_titlebar<T: 'static>(
     cx: &mut Context<T>,
     on_close: fn(&mut T, &ClickEvent, &mut Window, &mut Context<T>),
 ) -> Option<AnyElement> {
+    if cfg!(target_os = "macos") && window.is_fullscreen() {
+        return None;
+    }
+
     let layout = custom_titlebar_layout_for_target_os(
         std::env::consts::OS,
         window.window_decorations(),


### PR DESCRIPTION
## Summary

### Problem

The macOS titlebar looks a bit strange in both full-screen and non-full-screen modes.

Not in full-screen mode:

<img width="644" height="471" alt="image" src="https://github.com/user-attachments/assets/fc7e39b5-77f1-4c29-ac84-18bbe552f53c" />

In full-screen mode (the placement of this "Velotype" text doesn't look quite right either):

<img width="1505" height="989" alt="image" src="https://github.com/user-attachments/assets/f0bc1441-0163-4de6-ac4a-0556bb5a70ba" />

### Fix

This fixes two titlebar issues:

- Moves the native traffic light controls upward so they are vertically centered in Velotype's custom titlebar.
- Hides Velotype's custom titlebar while the window is fullscreen on macOS, letting the system fullscreen titlebar overlay handle the title and window controls.

In fullscreen, Velotype may not show its own persistent titlebar. When the pointer moves to the top edge, macOS can show the system fullscreen overlay with the traffic lights and title.

After this fix:

<img width="677" height="489" alt="image" src="https://github.com/user-attachments/assets/4a3cd7fe-c999-44fa-8716-792a48b2e234" />

<img width="1505" height="991" alt="image" src="https://github.com/user-attachments/assets/4840caae-dd58-4471-bb6c-f472ca8dc677" />

When the cursor moves over it:

<img width="1505" height="990" alt="image" src="https://github.com/user-attachments/assets/39a9190f-dd0e-416f-93c2-c290d5142c64" />

## Testing

Ran:

```bash
cargo fmt --check
cargo test titlebar
cargo check
```