### PR TITLE
Exit down from code block, math, mermaid, etc

### DIFF
--- a/src/components/block/interactions.rs
+++ b/src/components/block/interactions.rs
@@ -681,13 +681,21 @@ impl Block {
     pub(crate) fn on_focus_next(
         &mut self,
         _: &FocusNext,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let preferred_x = self.vertical_anchor_x();
         if !self.move_cursor_vertically(1, preferred_x, cx) {
             if self.is_table_cell() {
                 cx.emit(BlockEvent::RequestTableCellMoveVertical { delta: 1 });
+                return;
+            }
+            // In a code block, Down from the last content line steps into the
+            // language field rather than leaving the block, so the language is
+            // reachable by keyboard. A further Down there exits the block.
+            if self.kind().is_code_block() && !self.code_language_focus_handle.is_focused(window) {
+                self.code_language_focus_handle.focus(window);
+                cx.notify();
                 return;
             }
             cx.emit(BlockEvent::RequestFocusNext {
@@ -1250,8 +1258,10 @@ impl Block {
             return;
         }
         cx.stop_propagation();
-        self.focus_handle.focus(window);
-        cx.notify();
+        // Down from the language field leaves the code block: the editor focuses
+        // the block below, creating a trailing paragraph first when the code
+        // block is the last block. Enter does not exit (see on_code_language_newline).
+        cx.emit(BlockEvent::RequestFocusNext { preferred_x: None });
     }
 
     pub(crate) fn on_code_language_indent(
@@ -1663,16 +1673,7 @@ impl Block {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let exits_multiline_block = self.is_table_cell()
-            || self.kind().is_code_block()
-            || matches!(
-                self.kind(),
-                BlockKind::MathBlock
-                    | BlockKind::HtmlBlock
-                    | BlockKind::MermaidBlock
-                    | BlockKind::RawMarkdown
-                    | BlockKind::Comment
-            );
+        let exits_multiline_block = self.is_table_cell() || self.kind().is_multiline_text_block();
 
         if exits_multiline_block {
             cx.emit(BlockEvent::RequestNewline {

--- a/src/components/block/state.rs
+++ b/src/components/block/state.rs
@@ -220,6 +220,21 @@ impl BlockKind {
         matches!(self, Self::Callout(_))
     }
 
+    /// Blocks edited as multi-line raw text that render as self-contained
+    /// widgets (code, math, HTML, mermaid, comment, raw markdown). Exiting one
+    /// downward with `Down` or `Ctrl/Cmd+Enter` needs a line below to land on.
+    pub fn is_multiline_text_block(&self) -> bool {
+        self.is_code_block()
+            || matches!(
+                self,
+                Self::MathBlock
+                    | Self::HtmlBlock
+                    | Self::MermaidBlock
+                    | Self::Comment
+                    | Self::RawMarkdown
+            )
+    }
+
     pub fn is_footnote_definition(&self) -> bool {
         matches!(self, Self::FootnoteDefinition)
     }

--- a/src/editor/events.rs
+++ b/src/editor/events.rs
@@ -2189,6 +2189,23 @@ impl Editor {
             }
             BlockEvent::RequestFocusNext { preferred_x } => {
                 if current_visible_index + 1 >= visible_before.len() {
+                    // A trailing multi-line block (code, math, ...) has nowhere
+                    // below to move to, so give it a paragraph to land on and
+                    // focus that, matching how a trailing table behaves.
+                    if block.read(cx).kind().is_multiline_text_block() {
+                        self.ensure_trailing_paragraph_after_structural(&block, cx);
+                        let visible = self.document.flatten_visible_blocks();
+                        if let Some(landing) = visible
+                            .iter()
+                            .position(|v| v.entity.entity_id() == block.entity_id())
+                            .and_then(|index| visible.get(index + 1))
+                            .map(|v| v.entity.clone())
+                        {
+                            self.focus_block(landing.entity_id());
+                            landing.update(cx, |landing, cx| landing.move_to(0, cx));
+                            cx.notify();
+                        }
+                    }
                     return;
                 }
 
@@ -3572,6 +3589,93 @@ mod tests {
                 .first()
                 .map(|cell| cell.entity_id());
             assert_eq!(editor.pending_focus, header_cell);
+        });
+    }
+
+    #[gpui::test]
+    async fn down_out_of_code_block_focuses_following_block(cx: &mut TestAppContext) {
+        let editor =
+            cx.new(|cx| Editor::from_markdown(cx, "```rust\nab\n```\n\nafter".to_string(), None));
+
+        editor.update(cx, |editor, cx| {
+            let code = editor.document.first_root().expect("code root").clone();
+            assert!(code.read(cx).kind().is_code_block());
+            // Down from the language field emits RequestFocusNext; with a block
+            // below, focus lands there rather than creating anything.
+            editor.on_block_event(
+                code,
+                &BlockEvent::RequestFocusNext { preferred_x: None },
+                cx,
+            );
+
+            let following = editor.document.visible_blocks()[1].entity.clone();
+            assert_eq!(following.read(cx).display_text(), "after");
+            assert_eq!(editor.document.root_count(), 2);
+            assert_eq!(editor.pending_focus, Some(following.entity_id()));
+        });
+    }
+
+    #[gpui::test]
+    async fn down_out_of_trailing_code_block_creates_and_focuses_paragraph(
+        cx: &mut TestAppContext,
+    ) {
+        let editor = cx.new(|cx| Editor::from_markdown(cx, "```rust\nab\n```".to_string(), None));
+
+        editor.update(cx, |editor, cx| {
+            let code = editor.document.first_root().expect("code root").clone();
+            assert_eq!(editor.document.root_count(), 1);
+            editor.on_block_event(
+                code,
+                &BlockEvent::RequestFocusNext { preferred_x: None },
+                cx,
+            );
+
+            let roots = editor.document.root_blocks();
+            assert_eq!(roots.len(), 2);
+            assert_eq!(roots[1].read(cx).kind(), BlockKind::Paragraph);
+            assert_eq!(roots[1].read(cx).display_text(), "");
+            assert_eq!(editor.pending_focus, Some(roots[1].entity_id()));
+        });
+    }
+
+    #[gpui::test]
+    async fn down_out_of_trailing_math_block_creates_and_focuses_paragraph(
+        cx: &mut TestAppContext,
+    ) {
+        // Same miss as code blocks, one of the other multi-line widget blocks.
+        let editor = cx.new(|cx| Editor::from_markdown(cx, "$$\nx^2\n$$".to_string(), None));
+
+        editor.update(cx, |editor, cx| {
+            let math = editor.document.first_root().expect("math root").clone();
+            assert_eq!(math.read(cx).kind(), BlockKind::MathBlock);
+            editor.on_block_event(
+                math,
+                &BlockEvent::RequestFocusNext { preferred_x: None },
+                cx,
+            );
+
+            let roots = editor.document.root_blocks();
+            assert_eq!(roots.len(), 2);
+            assert_eq!(roots[1].read(cx).kind(), BlockKind::Paragraph);
+            assert_eq!(editor.pending_focus, Some(roots[1].entity_id()));
+        });
+    }
+
+    #[gpui::test]
+    async fn down_at_end_of_trailing_paragraph_creates_nothing(cx: &mut TestAppContext) {
+        // Regression guard: ordinary text blocks must not sprout a paragraph.
+        let editor = cx.new(|cx| Editor::from_markdown(cx, "hello".to_string(), None));
+
+        editor.update(cx, |editor, cx| {
+            let paragraph = editor.document.first_root().expect("paragraph").clone();
+            editor.on_block_event(
+                paragraph,
+                &BlockEvent::RequestFocusNext { preferred_x: None },
+                cx,
+            );
+
+            // No trailing paragraph is invented for an ordinary text block.
+            assert_eq!(editor.document.root_count(), 1);
         });
     }
 

--- a/src/editor/tests.rs
+++ b/src/editor/tests.rs
@@ -9,9 +9,9 @@ use gpui::{
 
 use super::{Editor, ViewMode};
 use crate::components::{
-    BlockKind, CloseWindow, ImageReferenceDefinitions, ImageResolvedSource, InlineTextTree,
-    QuitApplication, SaveDocument, TableCellInlineImageSegment, TableColumnAlignment,
-    parse_table_cell_inline_images, superscript_ordinal,
+    BlockKind, CloseWindow, FocusNext, ImageReferenceDefinitions, ImageResolvedSource,
+    InlineTextTree, Newline, QuitApplication, SaveDocument, TableCellInlineImageSegment,
+    TableColumnAlignment, parse_table_cell_inline_images, superscript_ordinal,
 };
 use crate::export::ExportFormat;
 use crate::i18n::{I18nManager, I18nStrings};
@@ -2729,6 +2729,84 @@ async fn captured_tab_key_inserts_visible_indent_in_paragraph(cx: &mut TestAppCo
     editor.update(cx, |editor, cx| {
         let block = editor.document.visible_blocks()[0].entity.clone();
         assert_eq!(block.read(cx).display_text(), "a    b");
+    });
+}
+
+#[gpui::test]
+async fn down_from_code_content_focuses_language_input(cx: &mut TestAppContext) {
+    init_editor_test_app(cx);
+    let (editor, cx) = cx.add_window_view(|_window, cx| {
+        Editor::from_markdown(cx, "```rust\nab\n```".to_string(), None)
+    });
+
+    // Settle focus on the code content first (and clear any pending focus that a
+    // later redraw would otherwise re-apply and steal back).
+    editor.update_in(cx, |editor, _window, cx| {
+        let block = editor.document.visible_blocks()[0].entity.clone();
+        editor.focus_block(block.entity_id());
+    });
+    redraw(cx);
+
+    editor.update_in(cx, |editor, window, cx| {
+        let block = editor.document.visible_blocks()[0].entity.clone();
+        block.update(cx, |block, block_cx| {
+            block.move_to(block.visible_len(), block_cx);
+            block.on_focus_next(&FocusNext, window, block_cx);
+        });
+        assert!(
+            block.read(cx).code_language_focus_handle.is_focused(window),
+            "Down from the last code line should focus the language field"
+        );
+    });
+}
+
+#[gpui::test]
+async fn down_from_code_language_at_document_end_creates_trailing_paragraph(
+    cx: &mut TestAppContext,
+) {
+    init_editor_test_app(cx);
+    let (editor, cx) = cx.add_window_view(|_window, cx| {
+        Editor::from_markdown(cx, "```rust\nab\n```".to_string(), None)
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        let block = editor.document.visible_blocks()[0].entity.clone();
+        editor.focus_block(block.entity_id());
+        block.update(cx, |block, block_cx| {
+            block.code_language_focus_handle.focus(window);
+            block.on_code_language_focus_next(&FocusNext, window, block_cx);
+        });
+    });
+    redraw(cx);
+
+    editor.update(cx, |editor, cx| {
+        let roots = editor.document.root_blocks();
+        assert_eq!(roots.len(), 2, "a trailing paragraph should be created");
+        assert_eq!(roots[1].read(cx).kind(), BlockKind::Paragraph);
+        assert_eq!(roots[1].read(cx).display_text(), "");
+    });
+}
+
+#[gpui::test]
+async fn enter_in_code_language_does_not_exit_block(cx: &mut TestAppContext) {
+    init_editor_test_app(cx);
+    let (editor, cx) = cx.add_window_view(|_window, cx| {
+        Editor::from_markdown(cx, "```rust\nab\n```".to_string(), None)
+    });
+
+    editor.update_in(cx, |editor, window, cx| {
+        let block = editor.document.visible_blocks()[0].entity.clone();
+        editor.focus_block(block.entity_id());
+        block.update(cx, |block, block_cx| {
+            block.code_language_focus_handle.focus(window);
+            block.on_code_language_newline(&Newline, window, block_cx);
+        });
+    });
+    redraw(cx);
+
+    editor.update(cx, |editor, cx| {
+        // Enter must not leave the block, so no trailing paragraph appears.
+        assert_eq!(editor.document.root_count(), 1);
     });
 }
 


### PR DESCRIPTION
This PR adds the improvement requested in #99, allowing the user to press `Down` to exit code blocks, as well as other sibling blocks.

All changes are confined to the existing parser/runtime model. No new dependencies.

Unit tests have been added for the following.

## Summary

The capability to use `Down`to exit tables was added in #74, but not code blocks and other sibling blocks.

The functionality has now been added, reusing the existing trailing-paragraph helper that already backed tables. Please note that `Down` at the bottom of a code block's content now moves into the **language field** instead of skipping past, making the language reachable by keyboard. This seemed the optimal choice.

`Down` in the language field exits the block: it focuses the block below, or creates and focuses a trailing empty paragraph when the code block is the last block.

## Sibling blocks also receiving this improvement

The same "give it a line to land on" behavior now applies to every trailing multi-line widget block (math, HTML, mermaid, comment, raw markdown), which had the identical gap. They already emitted `RequestFocusNext` on `Down`, so the same handler branch fixes them at once. A new `BlockKind::is_multiline_text_block()` names this set; `on_exit_code_block` was refactored onto it to drop a duplicated match.

## Alternatives considered

- _Creating the trailing paragraph lazily on exit vs eagerly on creation (as tables do)._ Tables create it eagerly because focus moves past the table the moment it forms, so the paragraph is where the caret lands. Typing a code fence keeps the caret inside the block, so an empty paragraph appearing below while you type would be intrusive. Creating it on the `Down` exit gives the same end state without that noise, and still reuses `ensure_trailing_paragraph_after_structural`.