### PR TITLE
Fixes for culling issues

### DIFF
--- a/src/editor/mod.rs
+++ b/src/editor/mod.rs
@@ -88,9 +88,11 @@ pub struct Editor {
     /// their running sum stays correct as the document scrolls. Filled as rows
     /// paint; unknown rows use a minimum-height estimate.
     row_stride_cache: HashMap<EntityId, f32>,
-    /// Row range mounted last frame; only those rows shared one scroll offset, so
-    /// their adjacent-top differences are valid footprints for the cache.
-    prev_render_window: Option<(usize, usize)>,
+    /// Content column the cached footprints were measured at. Rows rewrap when it
+    /// changes, so entries from another width are discarded rather than reused.
+    row_stride_width: Option<f32>,
+    /// Where last frame's run sat among the scroll container's children.
+    prev_mounted_run: Option<MountedRun>,
     close_guard_installed: bool,
     show_unsaved_changes_dialog: bool,
     /// When true, the window will close after the next successful save.
@@ -172,14 +174,35 @@ struct ScrollbarGeometry {
     max_scroll_y: f32,
 }
 
-/// Windowing result: the run of rows to mount, plus the top/bottom spacer
-/// heights standing in for the culled rows.
+/// Windowing result: the run of rows to mount, plus the spacer heights standing
+/// in for the culled rows. `top_h` is the spacer directly above the run and
+/// `bottom_h` the one closing out the document.
 #[derive(Clone, Copy, Debug, PartialEq)]
 struct RenderWindow {
     run_start: usize,
     run_end: usize,
     top_h: f32,
     bottom_h: f32,
+    focus_island: Option<FocusIsland>,
+}
+
+/// Where a frame's mounted run sat among the scroll container's children, so the
+/// next frame can read its recorded bounds back by index. `child_count` is what
+/// makes that mapping checkable rather than assumed.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct MountedRun {
+    row_start: usize,
+    row_end: usize,
+    child_base: usize,
+    child_count: usize,
+}
+
+/// Focused row mounted on its own, away from the run. Its position relative to
+/// the run follows from `row`, and `lead_h` is the spacer directly above it.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct FocusIsland {
+    row: usize,
+    lead_h: f32,
 }
 
 /// Active drag session for the custom scrollbar thumb.
@@ -308,7 +331,8 @@ impl Editor {
             last_scroll_viewport_size: None,
             prev_visible_block_ids: Vec::new(),
             row_stride_cache: HashMap::new(),
-            prev_render_window: None,
+            row_stride_width: None,
+            prev_mounted_run: None,
             close_guard_installed: false,
             show_unsaved_changes_dialog: false,
             pending_close_after_save: false,

--- a/src/editor/render.rs
+++ b/src/editor/render.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, Instant};
 
 use gpui::*;
 
-use super::{Editor, InfoDialogKind, workspace::workspace_panel_width_for_viewport};
+use super::{Editor, InfoDialogKind, MountedRun, workspace::workspace_panel_width_for_viewport};
 use crate::app_menu::dispatch_menu_action_for_editor;
 use crate::components::CalloutVariant;
 use crate::components::{AddLanguageConfig, AddThemeConfig, Block, NoRecentFiles};
@@ -1767,20 +1767,10 @@ impl Render for Editor {
                     .saturating_sub(1)
             });
 
-        // A row's first block keys its cached height; its painted top (from last
-        // frame) feeds the footprints below.
+        // A row's first block keys its cached footprint.
         let row_first_ids: Vec<EntityId> = row_starts
             .iter()
             .map(|&start| visible_blocks[start].entity.entity_id())
-            .collect();
-        let row_tops: Vec<Option<f32>> = row_starts
-            .iter()
-            .map(|&start| {
-                visible_blocks[start]
-                    .entity
-                    .read_with(cx, |block, _cx| block.last_bounds)
-                    .map(|bounds| f32::from(bounds.top()))
-            })
             .collect();
 
         // On a structural edit the row indices no longer match last frame, so the
@@ -1797,15 +1787,33 @@ impl Render for Editor {
                 .collect();
         }
 
-        // Rows mounted together last frame shared one scroll offset, so their
-        // adjacent painted-top differences are scroll-free heights. Caching those,
-        // not raw positions, is what keeps the window stable while scrolling.
-        if !structural_change {
-            if let Some((prev_start, prev_end)) = self.prev_render_window {
-                let prev_end = prev_end.min(row_first_ids.len());
-                for row in prev_start..prev_end.saturating_sub(1) {
-                    if let (Some(top), Some(next_top)) = (row_tops[row], row_tops[row + 1]) {
-                        let stride = next_top - top;
+        // A footprint only holds for the column it was measured at. The first
+        // frame has no scroll bounds yet, so the column collapses to its 1px
+        // floor and every block wraps a character per line; keeping those
+        // measurements would leave the document permanently mis-sized.
+        let width_changed = self.row_stride_width != Some(centered_width);
+        if width_changed {
+            self.row_stride_cache.clear();
+            self.row_stride_width = Some(centered_width);
+        }
+
+        // The scroll container records every mounted child's layout bounds, so
+        // adjacent tops differ by exactly one row's footprint whatever the row
+        // holds. Caching those differences, not raw positions, keeps the window
+        // stable while scrolling.
+        if !structural_change && !width_changed {
+            if let Some(prev) = self
+                .prev_mounted_run
+                .filter(|prev| self.mounted_run_is_addressable(*prev))
+            {
+                let prev_end = prev.row_end.min(row_first_ids.len());
+                for row in prev.row_start..prev_end.saturating_sub(1) {
+                    let child = prev.child_base + row - prev.row_start;
+                    if let (Some(bounds), Some(next_bounds)) = (
+                        self.scroll_handle.bounds_for_item(child),
+                        self.scroll_handle.bounds_for_item(child + 1),
+                    ) {
+                        let stride = f32::from(next_bounds.top() - bounds.top());
                         if stride > 0.0 && stride.is_finite() {
                             self.row_stride_cache.insert(row_first_ids[row], stride);
                         }
@@ -1835,39 +1843,64 @@ impl Render for Editor {
             RENDER_OVERDRAW_PX,
             focus_row,
         );
-        self.prev_render_window = Some((render_window.run_start, render_window.run_end));
 
-        // The first mounted row re-applies its `mt`, so drop it from the top
-        // spacer to avoid shifting content down by a gap.
-        let top_h = match row_top_gaps.get(render_window.run_start) {
-            Some(gap) => (render_window.top_h - gap).max(0.0),
-            None => render_window.top_h,
+        let island = render_window.focus_island;
+        let island_before_run = island.is_some_and(|island| island.row < render_window.run_start);
+        // A mounted row re-applies its own `mt`, which the preceding stride
+        // already covered, so every spacer sheds the gap of the row it precedes.
+        let spacer_before = |row: usize, height: f32| -> f32 {
+            match row_top_gaps.get(row) {
+                Some(gap) => (height - gap).max(0.0),
+                None => height,
+            }
         };
         let mut block_rows: Vec<AnyElement> =
-            Vec::with_capacity(render_window.run_end - render_window.run_start + 2);
-        if top_h > 0.5 {
-            block_rows.push(
-                div()
-                    .w_full()
-                    .flex_shrink_0()
-                    .h(px(top_h))
-                    .into_any_element(),
-            );
-        }
-        for (row_index, element) in row_elements.into_iter().enumerate() {
-            if row_index >= render_window.run_start && row_index < render_window.run_end {
-                block_rows.push(element);
+            Vec::with_capacity(render_window.run_end - render_window.run_start + 4);
+        let push_spacer = |rows: &mut Vec<AnyElement>, height: f32| {
+            if height > 0.5 {
+                rows.push(
+                    div()
+                        .w_full()
+                        .flex_shrink_0()
+                        .h(px(height))
+                        .into_any_element(),
+                );
             }
+        };
+
+        let mut row_elements: Vec<Option<AnyElement>> =
+            row_elements.into_iter().map(Some).collect();
+        let mut take_row = |rows: &mut Vec<AnyElement>, row: usize| {
+            if let Some(element) = row_elements.get_mut(row).and_then(Option::take) {
+                rows.push(element);
+            }
+        };
+
+        if let Some(island) = island.filter(|_| island_before_run) {
+            push_spacer(&mut block_rows, spacer_before(island.row, island.lead_h));
+            take_row(&mut block_rows, island.row);
         }
-        if render_window.bottom_h > 0.5 {
-            block_rows.push(
-                div()
-                    .w_full()
-                    .flex_shrink_0()
-                    .h(px(render_window.bottom_h))
-                    .into_any_element(),
-            );
+        push_spacer(
+            &mut block_rows,
+            spacer_before(render_window.run_start, render_window.top_h),
+        );
+        let run_child_base = block_rows.len();
+        for row in render_window.run_start..render_window.run_end {
+            take_row(&mut block_rows, row);
         }
+        if let Some(island) = island.filter(|_| !island_before_run) {
+            push_spacer(&mut block_rows, spacer_before(island.row, island.lead_h));
+            take_row(&mut block_rows, island.row);
+        }
+        push_spacer(&mut block_rows, render_window.bottom_h);
+        // Next frame reads the run's footprints back at these child indices, and
+        // re-checks `child_count` before trusting them.
+        self.prev_mounted_run = Some(MountedRun {
+            row_start: render_window.run_start,
+            row_end: render_window.run_end,
+            child_base: run_child_base,
+            child_count: block_rows.len(),
+        });
 
         let scroll_content = div()
             .id("editor-scroll-inner")

--- a/src/editor/tests.rs
+++ b/src/editor/tests.rs
@@ -7,7 +7,7 @@ use gpui::{
     VisualTestContext,
 };
 
-use super::{Editor, ViewMode};
+use super::{Editor, MountedRun, ViewMode};
 use crate::components::{
     BlockKind, CloseWindow, FocusNext, ImageReferenceDefinitions, ImageResolvedSource,
     InlineTextTree, Newline, QuitApplication, SaveDocument, TableCellInlineImageSegment,
@@ -134,8 +134,37 @@ fn rendered_window_keeps_focus_row_mounted() {
     // Viewport at the top, caret parked far below at row 80.
     let window = Editor::rendered_window(&strides, 0.0, 400.0, 0.0, Some(80));
 
+    // The caret rides its own island; the rows above it stay culled.
     assert_eq!(window.run_start, 0);
-    assert_eq!(window.run_end, 81);
+    assert_eq!(window.run_end, 9);
+    let island = window.focus_island.expect("caret row stays mounted");
+    assert_eq!(island.row, 80);
+    assert!((island.lead_h - 3550.0).abs() < 0.01);
+}
+
+#[test]
+fn rendered_window_focus_above_run_does_not_widen_it() {
+    // Reading downward leaves the caret at the top of the document, so the rows
+    // between it and the viewport must stay culled.
+    let strides = uniform_strides(100, 50.0);
+    let window = Editor::rendered_window(&strides, 2000.0, 400.0, 0.0, Some(0));
+
+    assert_eq!(window.run_start, 39);
+    assert_eq!(window.run_end, 49);
+    let island = window.focus_island.expect("caret row stays mounted");
+    assert_eq!(island.row, 0);
+    assert_eq!(island.lead_h, 0.0);
+    assert!((window.top_h - 1900.0).abs() < 0.01);
+}
+
+#[test]
+fn rendered_window_focus_inside_run_needs_no_island() {
+    let strides = uniform_strides(100, 50.0);
+    let window = Editor::rendered_window(&strides, 2000.0, 400.0, 0.0, Some(42));
+
+    assert_eq!(window.run_start, 39);
+    assert_eq!(window.run_end, 49);
+    assert_eq!(window.focus_island, None);
 }
 
 #[test]
@@ -179,8 +208,11 @@ fn rendered_window_preserves_total_height() {
     ] {
         let window = Editor::rendered_window(&strides, scroll_y, viewport_height, 200.0, focus);
         let rendered: f32 = strides[window.run_start..window.run_end].iter().sum();
+        let island: f32 = window
+            .focus_island
+            .map_or(0.0, |island| island.lead_h + strides[island.row]);
         assert!(
-            (window.top_h + rendered + window.bottom_h - total).abs() < 0.01,
+            (window.top_h + rendered + island + window.bottom_h - total).abs() < 0.01,
             "height invariant broken at scroll {scroll_y}"
         );
     }
@@ -211,6 +243,144 @@ fn rendered_window_all_estimated_windows_near_top() {
     assert!(window.run_end < strides.len());
     // A viewport-plus-band worth of rows, not the whole document.
     assert!(window.run_end >= 20);
+}
+
+#[test]
+fn rendered_window_scrolled_past_estimates_mounts_trailing_run() {
+    // Rows the window has never mounted are lower bounds, so the scroll offset
+    // can sit past their running sum. The tail must still fill the viewport.
+    let strides = uniform_strides(100, 20.0); // total 2000
+    let window = Editor::rendered_window(&strides, 9000.0, 400.0, 200.0, None);
+
+    assert_eq!(window.run_end, 100);
+    assert_eq!(window.bottom_h, 0.0);
+    let mounted: f32 = strides[window.run_start..window.run_end].iter().sum();
+    assert!(
+        mounted >= 600.0,
+        "a viewport plus overdraw must stay mounted, got {mounted}px"
+    );
+}
+
+#[gpui::test]
+async fn footprints_are_dropped_when_the_scroll_column_changes_shape(cx: &mut TestAppContext) {
+    init_editor_test_app(cx);
+    // Footprints are read back by child index, so anything added to the scroll
+    // column would pair them with the wrong rows. The count has to be re-checked
+    // rather than assumed, or the mismatch is silent.
+    let markdown = (0..60)
+        .map(|index| format!("## Section {index}\n\nParagraph {index}.\n"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let (editor, cx) = cx.add_window_view(|_window, cx| Editor::from_markdown(cx, markdown, None));
+    for _ in 0..3 {
+        redraw(cx);
+    }
+
+    editor.read_with(cx, |editor, _cx| {
+        let run = editor.prev_mounted_run.expect("a run was mounted");
+        assert!(
+            editor.mounted_run_is_addressable(run),
+            "the run the column just emitted must be readable"
+        );
+        for drift in [run.child_count + 1, run.child_count - 1] {
+            assert!(
+                !editor.mounted_run_is_addressable(MountedRun {
+                    child_count: drift,
+                    ..run
+                }),
+                "a column emitting {drift} children instead of {} must not be trusted",
+                run.child_count
+            );
+        }
+    });
+}
+
+#[gpui::test]
+async fn reading_to_the_bottom_leaves_the_caret_row_behind(cx: &mut TestAppContext) {
+    init_editor_test_app(cx);
+    // Scrolling never moves the caret, so it stays where the document loaded.
+    // The rows between it and the viewport must not ride along.
+    let markdown = (0..200)
+        .map(|index| format!("## Section {index}\n\nParagraph body for section {index}.\n"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let (editor, cx) = cx.add_window_view(|_window, cx| Editor::from_markdown(cx, markdown, None));
+    for _ in 0..3 {
+        redraw(cx);
+    }
+
+    for _ in 0..10 {
+        editor.update(cx, |editor, _cx| {
+            let max = editor.scroll_handle.max_offset().height;
+            editor
+                .scroll_handle
+                .set_offset(gpui::point(gpui::px(0.0), -max));
+        });
+        redraw(cx);
+        redraw(cx);
+    }
+
+    editor.read_with(cx, |editor, _cx| {
+        let run = editor.prev_mounted_run.expect("a run was mounted");
+        let (run_start, run_end) = (run.row_start, run.row_end);
+        let rows = editor.document.visible_blocks().len();
+        assert!(
+            run_start > 0,
+            "the caret's row dragged the whole prefix on screen"
+        );
+        assert!(
+            run_end - run_start < rows / 4,
+            "{} of {rows} rows mounted at the bottom of the document",
+            run_end - run_start
+        );
+    });
+}
+
+#[gpui::test]
+async fn document_present_on_the_first_frame_is_measured_at_the_real_width(
+    cx: &mut TestAppContext,
+) {
+    init_editor_test_app(cx);
+    // Launching with a file renders one frame before the scroll bounds exist,
+    // collapsing the content column to its floor so every block wraps a
+    // character per line. Caching those footprints would size the document from
+    // a layout the reader never sees.
+    let markdown = (0..40)
+        .map(|index| {
+            format!(
+                "## Section {index}\n\nA paragraph with enough words in it to wrap many times over \
+                 once the content column narrows to a sliver.\n"
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+    let (editor, cx) = cx.add_window_view(|_window, cx| Editor::from_markdown(cx, markdown, None));
+
+    for _ in 0..4 {
+        redraw(cx);
+    }
+
+    editor.read_with(cx, |editor, _cx| {
+        let widest = editor
+            .row_stride_cache
+            .values()
+            .fold(0.0f32, |widest, stride| widest.max(*stride));
+        assert!(
+            widest > 0.0 && widest < 200.0,
+            "headings and one-line paragraphs cannot be {widest}px tall; \
+             the first frame's collapsed column was cached"
+        );
+        let run = editor.prev_mounted_run.expect("a run was mounted");
+        assert_eq!(
+            run.row_start, 0,
+            "the top of the document must stay mounted"
+        );
+        assert!(
+            run.row_end > 8,
+            "only {} rows mounted, so the viewport is mostly spacer",
+            run.row_end
+        );
+    });
 }
 
 #[test]

--- a/src/editor/window_state.rs
+++ b/src/editor/window_state.rs
@@ -48,12 +48,30 @@ impl Editor {
         max_scroll_y * progress
     }
 
-    /// Picks the contiguous run of rows to mount; the culled runs become two
-    /// spacers and the focused row stays mounted. `strides[i]` is row `i`'s
+    /// Whether last frame's child indices still address the same children.
+    /// Footprints are read back by index, so anything added to the scroll column
+    /// would otherwise pair the wrong rows silently; a changed child count means
+    /// the recorded indices are stale and the refresh must be skipped.
+    pub(super) fn mounted_run_is_addressable(&self, run: MountedRun) -> bool {
+        run.child_count > 0
+            && self
+                .scroll_handle
+                .bounds_for_item(run.child_count - 1)
+                .is_some()
+            && self
+                .scroll_handle
+                .bounds_for_item(run.child_count)
+                .is_none()
+    }
+
+    /// Picks the contiguous run of rows to mount; the culled runs become
+    /// spacers and the focused row stays mounted, on its own island when it
+    /// falls outside the run. `strides[i]` is row `i`'s
     /// footprint (height plus trailing gap); being scroll-invariant, their running
     /// sum places each row against a band from the current scroll offset.
-    /// Unmeasured rows use a lower-bound estimate, so the window never lands on a
-    /// spacer. Pure, so it is unit-tested headlessly.
+    /// Unmeasured rows use a lower-bound estimate; where that falls short of the
+    /// scroll offset the trailing run is mounted instead, so the window never
+    /// lands on a spacer. Pure, so it is unit-tested headlessly.
     pub(super) fn rendered_window(
         strides: &[f32],
         scroll_y: f32,
@@ -68,6 +86,7 @@ impl Editor {
                 run_end: 0,
                 top_h: 0.0,
                 bottom_h: 0.0,
+                focus_island: None,
             };
         }
 
@@ -94,34 +113,56 @@ impl Editor {
         }
         let total = cursor;
 
-        // Nothing hit the band (float edge, or estimate short of scroll): mount
-        // the last row so the viewport never lands on a spacer.
+        // Nothing hit the band: the scroll offset is past everything the strides
+        // account for, because rows the window has yet to mount are still lower
+        // bounds. Fall back to the trailing run rather than a single row, so the
+        // viewport stays filled while the remaining heights are learned.
         if run_start >= run_end {
-            run_start = n - 1;
             run_end = n;
-            top_of_start = total - strides[n - 1].max(0.0);
             bottom_of_end = total;
+            run_start = n - 1;
+            top_of_start = total - strides[n - 1].max(0.0);
+            let floor = (total - viewport_height - overdraw).max(0.0);
+            while run_start > 0 && top_of_start > floor {
+                run_start -= 1;
+                top_of_start -= strides[run_start].max(0.0);
+            }
         }
 
-        // Keep the focused row mounted; GPUI blurs an unmounted caret. Reaching a
-        // far focus row widens the run, but autoscroll makes that rare.
-        if let Some(focus_row) = focus_row {
-            let focus_row = focus_row.min(n - 1);
+        // Keep the focused row mounted; GPUI blurs an unmounted caret. It goes on
+        // its own island rather than widening the run, so a caret left behind
+        // while reading does not drag every row between it and the viewport on
+        // screen with it.
+        let mut top_h = top_of_start;
+        let mut bottom_h = total - bottom_of_end;
+        let mut focus_island = None;
+        if let Some(focus_row) = focus_row.map(|row| row.min(n - 1)) {
+            let focus_top: f32 = strides[..focus_row].iter().map(|s| s.max(0.0)).sum();
+            let focus_bottom = focus_top + strides[focus_row].max(0.0);
             if focus_row < run_start {
-                run_start = focus_row;
-                top_of_start = strides[..focus_row].iter().map(|s| s.max(0.0)).sum();
-            }
-            if focus_row + 1 > run_end {
-                run_end = focus_row + 1;
-                bottom_of_end = strides[..=focus_row].iter().map(|s| s.max(0.0)).sum();
+                focus_island = Some(FocusIsland {
+                    row: focus_row,
+                    lead_h: focus_top,
+                });
+                top_h = top_of_start - focus_bottom;
+            } else if focus_row >= run_end {
+                focus_island = Some(FocusIsland {
+                    row: focus_row,
+                    lead_h: focus_top - bottom_of_end,
+                });
+                bottom_h = total - focus_bottom;
             }
         }
 
         RenderWindow {
             run_start,
             run_end,
-            top_h: top_of_start.max(0.0),
-            bottom_h: (total - bottom_of_end).max(0.0),
+            top_h: top_h.max(0.0),
+            bottom_h: bottom_h.max(0.0),
+            focus_island: focus_island.map(|island| FocusIsland {
+                lead_h: island.lead_h.max(0.0),
+                ..island
+            }),
         }
     }
 


### PR DESCRIPTION

# Fixes for culling issues

This PR fixes the #100 regressions mentioned in #106 and #112.

All changes are confined to the existing parser/runtime model. No new dependencies.

Unit tests have been added for all of the following.

## The problems

Viewport culling (#100) sizes the document from a cache of per-row footprints, with three flaws now addressed.

### Incomplete rendering (#106)

`Editor::render` derives the content column from the scroll handle's bounds. On the first frame the scroll handle has not been laid out, so its bounds are zero. `viewport_width` clamps to 1px, and `centered_column_width` clamps back down to 1px on its final `.min(available_content_width)`. Every row lays out 1px wide.

That frame was always garbage, and before culling it was harmless. It is invisible, and the next frame relaid everything at the real width. Culling made it permanent, because the next frame reads those painted tops and stores them as measured footprints. The cache is keyed by block `EntityId` with no width key and no invalidation, so the 1px measurements stick.

The painted heights are exactly one rendered line per character, which is the signature:

This only bites when the document is present on the first frame, which is why it does not reproduce for everyone. Open the editor empty and then use File > Open and the bounds are already valid, the blocks get fresh ids, and everything measures correctly.

### Culling defeated while reading

`rendered_window` kept the focused row mounted by widening the run to include it. Since scrolling does not move the caret, the caret stays where the document loaded and the run grows between it and the viewport as it moves down. Autoscroll only fires when the caret moves, which is exactly what does not happen while reading.

### Rows that cannot be measured

A footprint was the difference between two rows' first blocks reporting painted text bounds. Tables and image-only paragraphs carry no text element, so they report none.

While culling was defeated by the caret this only skewed the scrollbar, since the mounted set was the same either way. Once culling engages, footprint accuracy directly controls how much gets mounted.

## Applied solutions in this PR

**1. Footprints are now keyed to the column they were measured at.** A new `row_stride_width` records it; when the column changes, the cache is dropped and that frame's refresh is skipped. This absorbs the 1px first frame and any brief narrow layout. The starved-window fallback now mounts the trailing run rather than a single row, so an unmeasured tail degrades to a filled viewport instead of a near-blank one.

**2. The focused row is now mounted on its own island.** Rather than widening the run, it sits between spacers that hold its place. The caret keeps its element so GPUI does not blur it, and the run stays sized to the viewport wherever the caret sits. Every spacer sheds the top gap of the row it precedes, since that row re-applies it.

**3. Footprints come from the mounted children.** The scroll container already records every mounted child's layout bounds, so adjacent tops give the footprint whatever the row holds. The exception being the last row, which has no successor and is an acceptable omission. Reading those bounds means addressing children by index...the run records how many children the column emitted and re-checks that count before trusting the mapping. Adding anything to the scroll column changes the count and drops the frame back to estimates, rather than silently pairing footprints with the wrong rows.

## Results

This fixes the incomplete rendering and dramatically increases performance in these cases. The table below shows before and after comparison of some automated test files. The ratios are what matter here.

| automated test document          | rows mounted | frame |
| -------------------------------- | ------------ | ----- |
| 379 rows, **before**             | 379 of 379   | 118ms |
| 379 rows, **after**              | 15           | 27ms  |
| table-heavy 185 rows, **before** | 49 of 185    | 253ms |
| table-heavy 185 rows, **after**  | 8            | 104ms |

The issue #106 file renders in full: 62,393px becomes 6,304px, and every block reaches the screen.

This also addresses the rendering lag reported in issue #112, whose test file is the 379 row document above.

## Alternatives considered, decided against

- **Clearing the footprint cache whenever the viewport is not yet laid out, rather than keying on width.** This would only cover the first frame. For example, a window being dragged would poison the cache just the same.
- **Letting the caret blur when it scrolls off screen, instead of mounting it detached.** This would lose IME composition state, the selection, and the caret position.
- **Capping how far the run may widen to reach the caret.** The run would still boundlessly grow while reading, just more slowly.
- **Recording painted bounds on table and image blocks so the original footprint source keeps working.** This would touch every block kind that lacks a text element and maintaining a second reporting path, when the scroll container already records exactly these bounds for every mounted child.